### PR TITLE
Publish MiniMax H3 Audio T8 nodes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+
+*.json text eol=lf
+*.md text eol=lf
+*.py text eol=lf
+*.toml text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.pytest_cache/
+*.py[cod]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+SPDX-License-Identifier: GPL-3.0-or-later
+
+Copyright (C) 2026 MiniMax H3 Audio T8 contributors
+
+This program is free software: you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation, either version 3 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE. See <https://www.gnu.org/licenses/gpl-3.0.html> for the full
+license text. The containing ComfyUI distribution also includes a copy of GPLv3.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,83 @@
-# minimax-h3-audio-T8
+# MiniMax H3 Audio T8
+
+面向当前 ComfyUI 原生 MiniMax H3 的独立音频节点包。它不修改旧的
+`comfyui-vrgamedevgirl`，节点统一位于 `T8/MiniMax H3/Audio`。
+
+本包不是把源音频简单塞进 latent：它按 ComfyUI 当前 H3 实现维护媒体展示顺序、
+`<Picture N>` / `<Video N>` / `<Audio N>` 标签、联合 AV latent、首尾关键帧、参考媒体和
+噪声掩码之间的契约。
+
+## 节点
+
+| 节点 | 用途 |
+|---|---|
+| MiniMax H3 Audio Conditioning (T8) | T2VA、I2VA、FL2VA、L2VA、Ref2VA 和关键帧+参考媒体 Hybrid 的统一条件节点 |
+| MiniMax H3 Audio Latent Control (T8) | 对已有 H3 AV latent 锁定或重绘源音频，并保留已有视频 mask |
+| MiniMax H3 Duration Planner (T8) | 把场景时间换算成 24fps、`17n+5` 的渲染窗口和最终裁切参数 |
+| MiniMax H3 Audio Window (T8) | 直接切取/补零 AUDIO，短场景可自动扩展到 124 帧训练下限 |
+| MiniMax H3 Prompt Tags (T8) | 把 `Image 1`、`Audio1` 等写法规范为官方标签并严格校验编号 |
+| MiniMax H3 AV Decode (T8) | 用视频/音频 VAE 分别解码联合 AV latent |
+| MiniMax H3 Audio Mix (T8) | 源音轨与模型生成音轨重采样、增益、ducking、峰值限制后混合 |
+| MiniMax H3 Output Trim (T8) | 把 Planner 的时间窗口同时应用到解码帧和音频 |
+| MiniMax H3 Preflight (T8) | 在采样前检查模型、尺寸、帧数、音频、参考数量和参考视频时长 |
+
+## 四种音频模式
+
+| 模式 | 目标音频 latent | 源音频是否作为参考 | 适用场景 |
+|---|---|---|---|
+| `lock_source` | 源音频，denoise mask=0 | 默认是 | 画面严格跟随音频，最终保留原音轨 |
+| `remix_source` | 源音频，按 strength 重绘 | 默认是 | 保留节奏/语音结构，同时让模型改造声音 |
+| `reference_only` | 空白、完整生成 | 是 | 源音频只提供语义/节奏参考，输出使用模型音频 |
+| `native` | 空白、完整生成 | 否 | 纯 H3 原生音画联合生成，无需输入音频 |
+
+`drive_audio` 是给模型的驱动轨，`final_audio` 是最终 mux 的干净轨。二者分开可以让你把
+外部人声分离器得到的 vocal stem 用作驱动，同时把原混音或另一条 stem 送到最终输出；
+本包不会假装内置了一个未经验证的分离模型。
+
+## 推荐连接
+
+锁定原音频生成画面：
+
+1. `Load Audio -> MiniMax H3 Audio Window (T8)`。
+2. `context_audio`、视频 VAE、音频 VAE、CLIP 接入统一 Conditioning，选择 `lock_source`。
+3. Conditioning 的 `positive` 和 `av_latent` 进入原生 H3 sampler。
+4. sampler 输出进入 `MiniMax H3 AV Decode (T8)`。
+5. 解码 frames、Conditioning 的 `mux_audio`、Audio Window 的两个 trim 输出进入
+   `MiniMax H3 Output Trim (T8)`。
+6. 将裁切后的 frames/audio 交给 VideoHelperSuite 或你现有的保存节点。
+
+短场景开启 `ensure_minimum_context` 时，节点会添加上下文，但不会再让动作时间轴悄悄漂移：
+`prompt_timing_note` 给出主场景在渲染窗口中的真实开始/结束时间，最终 trim 参数再恢复用户请求时长。
+
+## 媒体编号
+
+H3 的展示顺序是：所有 Picture；然后每个参考视频（其声轨 Audio 标签位于对应 Video
+标签前）；最后是独立 Audio。因而两个参考视频都带声轨时，主驱动音频会是 `<Audio 3>`，
+而不是 `<Audio 1>`。统一 Conditioning 会输出完整 `media_map_json`，并把 prompt 中配置的
+`prompt_primary_audio_ordinal` 自动映射到主驱动音频的真实编号。设为 0 可关闭重映射。
+
+严格模式会拒绝引用未连接媒体的标签，避免模型收到看似合法、实际无对应条件的 prompt。
+
+## H3 边界
+
+- 固定 24fps，帧数向上对齐到 `17n+5`。
+- 当前模型近似训练区间为 124–362 帧；区间外允许规划但 Preflight 会警告。
+- 生成画布像素面积不能超过 `768*1344`，宽高必须是 32 的倍数。
+- 原生 H3 目前只支持 batch size 1。
+- 引用上限：9 张 Picture、3 个 Video、3 个独立 Audio；参考视频官方建议 2–15 秒。
+- `Hybrid` 同时使用精确首/尾帧和参考媒体。节点包含针对当前 ComfyUI `PackedLayout`
+  行为的运行时契约检查；上游若改变结构会明确停止，而不是生成错位条件。
+
+## 示例与测试
+
+API 示例见 `examples/audio_lock_api.json`。替换里面的模型、VAE、CLIP 和音频文件名后即可使用；
+保存节点使用已安装的 VideoHelperSuite。
+
+从 ComfyUI 根目录、使用启动 ComfyUI 的同一 Python 环境运行：
+
+```powershell
+$env:PYTHONPATH=(Get-Location).Path
+python -m pytest -q .\custom_nodes\minimax-h3-audio-T8
+```
+
+本包没有额外 pip 依赖，使用 ComfyUI 自带的 PyTorch、torchaudio 和原生 MiniMax H3 实现。

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,22 @@
+if __package__:
+    from .nodes import comfy_entrypoint
+else:  # Allows direct test collection from a hyphenated custom-node directory.
+    import importlib.util
+    from pathlib import Path
+    import sys
+    import types
+
+    _package_name = "_minimax_h3_audio_t8_direct"
+    _package_root = Path(__file__).resolve().parent
+    _package = types.ModuleType(_package_name)
+    _package.__path__ = [str(_package_root)]
+    sys.modules.setdefault(_package_name, _package)
+    _spec = importlib.util.spec_from_file_location(f"{_package_name}.nodes", _package_root / "nodes.py")
+    _nodes = importlib.util.module_from_spec(_spec)
+    sys.modules[_spec.name] = _nodes
+    assert _spec.loader is not None
+    _spec.loader.exec_module(_nodes)
+    comfy_entrypoint = _nodes.comfy_entrypoint
+
+
+__all__ = ["comfy_entrypoint"]

--- a/audio_ops.py
+++ b/audio_ops.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+
+import torch
+import torch.nn.functional as torch_functional
+import torchaudio
+
+from comfy_extras.nodes_audio import vae_decode_audio
+
+from .core import encode_audio_once, nested_av_parts, replace_audio_latent, validate_audio
+
+
+def inject_audio_latent(av_latent: dict, source_audio: dict, audio_vae, mode: str, strength: float):
+    mode = mode.lower()
+    if mode not in {"lock", "remix"}:
+        raise ValueError("Audio latent control mode must be lock or remix")
+    if not 0.0 <= strength <= 1.0:
+        raise ValueError("strength must be between 0 and 1")
+    encoded = encode_audio_once(audio_vae, source_audio)
+    denoise = 0.0 if mode == "lock" else strength
+    return replace_audio_latent(av_latent, encoded, denoise), source_audio
+
+
+def decode_av_latent(av_latent: dict, video_vae, audio_vae):
+    video, audio = nested_av_parts(av_latent)
+    images = video_vae.decode(video)
+    if images.ndim == 5:
+        images = images.reshape(-1, *images.shape[-3:])
+    decoded_audio = vae_decode_audio(audio_vae, {"samples": audio})
+    video_latent = {key: value for key, value in av_latent.items() if key not in {"samples", "noise_mask"}}
+    audio_latent = video_latent.copy()
+    video_latent["samples"] = video
+    audio_latent["samples"] = audio
+    masks = av_latent.get("noise_mask")
+    if getattr(masks, "is_nested", False):
+        video_mask, audio_mask = masks.unbind()
+        video_latent["noise_mask"] = video_mask
+        audio_latent["noise_mask"] = audio_mask
+    return images, decoded_audio, video_latent, audio_latent
+
+
+def _resample(waveform: torch.Tensor, source_rate: int, target_rate: int) -> torch.Tensor:
+    if source_rate == target_rate:
+        return waveform
+    return torchaudio.functional.resample(waveform, source_rate, target_rate)
+
+
+def _match_channels(waveform: torch.Tensor, target_channels: int) -> torch.Tensor:
+    channels = waveform.shape[1]
+    if channels == target_channels:
+        return waveform
+    if channels == 1:
+        return waveform.expand(-1, target_channels, -1)
+    if target_channels == 1:
+        return waveform.mean(dim=1, keepdim=True)
+    # For uncommon multichannel inputs, make a deterministic stereo-compatible downmix.
+    mono = waveform.mean(dim=1, keepdim=True)
+    return mono.expand(-1, target_channels, -1)
+
+
+def mix_audio(
+    source_audio: dict,
+    generated_audio: dict,
+    source_gain_db: float = 0.0,
+    generated_gain_db: float = -6.0,
+    duck_generated: float = 0.5,
+    output_sample_rate: str = "source",
+    peak_limit_dbfs: float = -1.0,
+):
+    source, source_rate = validate_audio(source_audio, "source_audio")
+    generated, generated_rate = validate_audio(generated_audio, "generated_audio")
+    if output_sample_rate == "source":
+        target_rate = source_rate
+    elif output_sample_rate == "generated":
+        target_rate = generated_rate
+    else:
+        target_rate = int(output_sample_rate)
+
+    source = _resample(source, source_rate, target_rate)
+    generated = _resample(generated, generated_rate, target_rate)
+    target_channels = max(source.shape[1], generated.shape[1])
+    source = _match_channels(source, target_channels)
+    generated = _match_channels(generated, target_channels)
+    target_samples = max(source.shape[-1], generated.shape[-1])
+    source = torch_functional.pad(source, (0, target_samples - source.shape[-1]))
+    generated = torch_functional.pad(generated, (0, target_samples - generated.shape[-1]))
+
+    source = source * (10.0 ** (source_gain_db / 20.0))
+    generated = generated * (10.0 ** (generated_gain_db / 20.0))
+    if duck_generated > 0:
+        envelope = source.abs().mean(dim=1, keepdim=True)
+        window = max(1, round(target_rate * 0.02))
+        envelope = torch_functional.avg_pool1d(envelope, window, stride=1, padding=window // 2)
+        envelope = envelope[..., :target_samples]
+        activity = (envelope / 0.05).clamp(0.0, 1.0)
+        generated = generated * (1.0 - float(duck_generated) * activity)
+
+    mixed = source + generated
+    limit = 10.0 ** (peak_limit_dbfs / 20.0)
+    peak = mixed.abs().amax(dim=(1, 2), keepdim=True).clamp_min(1e-8)
+    scale = torch.minimum(torch.ones_like(peak), torch.full_like(peak, limit) / peak)
+    mixed = mixed * scale
+    return {"waveform": mixed, "sample_rate": target_rate}
+
+
+def trim_av_output(frames: torch.Tensor, start_seconds: float, duration_seconds: float, audio=None, fps: float = 24.0):
+    if frames.ndim != 4:
+        raise ValueError(f"frames must be IMAGE [N,H,W,C], got {tuple(frames.shape)}")
+    if start_seconds < 0 or duration_seconds <= 0 or fps <= 0:
+        raise ValueError("trim start must be nonnegative; duration and fps must be positive")
+    start_frame = round(start_seconds * fps)
+    frame_count = max(1, round(duration_seconds * fps))
+    end_frame = start_frame + frame_count
+    if end_frame > frames.shape[0]:
+        raise ValueError(
+            f"Requested output frames [{start_frame}:{end_frame}] exceed decoded frame count {frames.shape[0]}"
+        )
+    trimmed_frames = frames[start_frame:end_frame]
+
+    trimmed_audio = None
+    if audio is not None:
+        waveform, sample_rate = validate_audio(audio)
+        start_sample = round(start_seconds * sample_rate)
+        sample_count = round(duration_seconds * sample_rate)
+        sliced = waveform[..., start_sample : start_sample + sample_count]
+        if sliced.shape[-1] < sample_count:
+            sliced = torch_functional.pad(sliced, (0, sample_count - sliced.shape[-1]))
+        trimmed_audio = {"waveform": sliced, "sample_rate": sample_rate}
+
+    report = json.dumps(
+        {
+            "start_seconds": start_seconds,
+            "requested_duration_seconds": duration_seconds,
+            "fps": fps,
+            "start_frame": start_frame,
+            "frame_count": frame_count,
+            "actual_video_duration_seconds": frame_count / fps,
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+    return trimmed_frames, trimmed_audio, report

--- a/conditioning.py
+++ b/conditioning.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import inspect
+import math
+
+import torch
+
+import node_helpers
+from comfy.ldm.minimax.model import PackedLayout
+from comfy.model_base import MiniMaxH3 as MiniMaxH3BaseModel
+
+from .core import (
+    CANVAS_MULTIPLE,
+    FPS,
+    REF_IMAGE_SHORT_EDGE,
+    adapt_canvas,
+    align_frame_count_down,
+    empty_av_latent,
+    encode_audio_once,
+    fit_audio_latent,
+    nested_av_parts,
+    replace_audio_latent,
+    resize_image,
+    sorted_autogrow_items,
+    sorted_autogrow_values,
+)
+from .prompt_tags import media_map_json, prepare_prompt
+
+
+HYBRID_KEYFRAME_SENTINEL = "t8_keyframe_latent"
+
+
+def assert_hybrid_layout_contract() -> None:
+    """Fail loudly if upstream starts packing our sentinel as a real reference.
+
+    Current ComfyUI replaces keyframe cond latents with the ref latent list when
+    both payloads are present. The sentinel makes that latent list start with the
+    keyframes while PackedLayout intentionally ignores its unknown ref kind.
+    """
+    extra_conds_source = inspect.getsource(MiniMaxH3BaseModel.extra_conds)
+    required_contract = 'payload["cond_video_latents"] = [r["latent"] for r in refs if "latent" in r]'
+    if required_contract not in extra_conds_source:
+        raise RuntimeError(
+            "This ComfyUI build changed MiniMax H3 ref/keyframe latent assembly; "
+            "the T8 Hybrid path is disabled until its ordering can be revalidated."
+        )
+
+    keyframe = {"resolved_frame_index": 0, "latent": torch.zeros(1)}
+    baseline = PackedLayout(1, 2, 2, 2, 1, keyframes=[keyframe], frame_count=5)
+    hybrid = PackedLayout(
+        1,
+        2,
+        2,
+        2,
+        1,
+        keyframes=[keyframe],
+        refs=[{"kind": HYBRID_KEYFRAME_SENTINEL, "latent": torch.zeros(1)}],
+        frame_count=5,
+    )
+    if baseline.segments != hybrid.segments or baseline.seq_len != hybrid.seq_len:
+        raise RuntimeError(
+            "This ComfyUI build changed MiniMax H3 PackedLayout reference handling; "
+            "the T8 exact-keyframe + reference compatibility path is disabled to prevent corrupt conditioning."
+        )
+
+
+def resolve_task_type(task_type: str, first_frame, last_frame, has_refs: bool) -> str:
+    first = first_frame is not None
+    last = last_frame is not None
+    requested = (task_type or "auto").lower()
+    if requested == "auto":
+        if has_refs and (first or last):
+            return "hybrid"
+        if has_refs:
+            return "ref2va"
+        if first and last:
+            return "fl2va"
+        if first:
+            return "i2va"
+        if last:
+            return "l2va"
+        return "t2va"
+
+    requirements = {
+        "t2va": (False, False, False),
+        "i2va": (True, False, False),
+        "fl2va": (True, True, False),
+        "l2va": (False, True, False),
+        "ref2va": (False, False, True),
+        "hybrid": (None, None, True),
+    }
+    if requested not in requirements:
+        raise ValueError(f"Unknown MiniMax H3 task type: {task_type}")
+    need_first, need_last, need_refs = requirements[requested]
+    if need_first is not None and first != need_first:
+        raise ValueError(f"{requested.upper()} first_frame connection does not match the selected task")
+    if need_last is not None and last != need_last:
+        raise ValueError(f"{requested.upper()} last_frame connection does not match the selected task")
+    if need_refs and not has_refs:
+        raise ValueError(f"{requested.upper()} requires at least one reference media input")
+    if requested == "hybrid" and not (first or last):
+        raise ValueError("HYBRID requires first_frame and/or last_frame")
+    if requested not in {"ref2va", "hybrid"} and has_refs:
+        raise ValueError(f"{requested.upper()} cannot include reference media; use Auto or Hybrid")
+    return requested
+
+
+def _resize_reference_image(image, width: int, height: int, ref_image_size: str):
+    h, w = int(image.shape[1]), int(image.shape[2])
+    if ref_image_size == "match":
+        scale = min(1.0, math.sqrt((width * height) / (w * h)))
+    else:
+        scale = min(1.0, REF_IMAGE_SHORT_EDGE / min(w, h))
+    target_width = max(CANVAS_MULTIPLE, round(w * scale / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
+    target_height = max(CANVAS_MULTIPLE, round(h * scale / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
+    return resize_image(image[:1], target_width, target_height), target_width, target_height
+
+
+def _encode_reference_audio(audio_vae, audio: dict):
+    latent = encode_audio_once(audio_vae, audio)
+    return latent, int(latent.shape[-1])
+
+
+def build_conditioning(
+    clip,
+    video_vae,
+    audio_vae,
+    prompt: str,
+    width: int,
+    height: int,
+    length: int,
+    task_type: str = "auto",
+    audio_mode: str = "lock_source",
+    audio_denoise_strength: float = 0.35,
+    add_source_as_reference: bool = True,
+    prompt_primary_audio_ordinal: int = 1,
+    strict_prompt_tags: bool = True,
+    ref_image_size: str = "match",
+    reference_video_policy: str = "official_2_to_15s",
+    drive_audio=None,
+    final_audio=None,
+    first_frame=None,
+    last_frame=None,
+    ref_images=None,
+    ref_videos=None,
+    ref_video_audios=None,
+    ref_audios=None,
+):
+    if width % 32 or height % 32:
+        raise ValueError("MiniMax H3 width and height must be divisible by 32")
+    if width * height > 768 * 1344:
+        raise ValueError(
+            "Requested canvas exceeds MiniMax H3's native 768x1344 pixel-area cap; "
+            "reduce width/height to avoid an unvalidated VRAM path"
+        )
+    if not 0.0 <= audio_denoise_strength <= 1.0:
+        raise ValueError("audio_denoise_strength must be between 0 and 1")
+
+    ref_image_values = sorted_autogrow_values(ref_images)
+    ref_video_entries = sorted_autogrow_items(ref_videos)
+    ref_video_values = [value for _, value in ref_video_entries]
+    ref_audio_values = sorted_autogrow_values(ref_audios)
+    ref_video_audio_by_ordinal = dict(sorted_autogrow_items(ref_video_audios))
+    if len(ref_image_values) > 9 or len(ref_video_values) > 3 or len(ref_audio_values) > 3:
+        raise ValueError("MiniMax H3 reference limits are 9 pictures, 3 videos, and 3 standalone audios")
+    video_ordinals = {ordinal for ordinal, _ in ref_video_entries}
+    orphan_soundtracks = sorted(set(ref_video_audio_by_ordinal) - video_ordinals)
+    if orphan_soundtracks:
+        raise ValueError(
+            "Reference-video soundtrack(s) have no same-numbered video: "
+            + ", ".join(map(str, orphan_soundtracks))
+        )
+
+    mode = audio_mode.lower()
+    if mode not in {"native", "reference_only", "lock_source", "remix_source"}:
+        raise ValueError(f"Unknown audio mode: {audio_mode}")
+    if mode != "native" and drive_audio is None:
+        raise ValueError(f"Audio mode {audio_mode} requires drive_audio")
+    if drive_audio is None and add_source_as_reference:
+        add_source_as_reference = False
+
+    latent, frame_count = empty_av_latent(width, height, length)
+    _, template_audio = nested_av_parts(latent)
+
+    keyframes = []
+    keyframe_images = []
+    picture_labels: list[str] = []
+    if first_frame is not None:
+        image = resize_image(first_frame[:1], width, height, "disabled")
+        keyframe_images.append(image)
+        picture_labels.append("first_frame (exact frame 0)")
+        keyframes.append({"resolved_frame_index": 0, "latent": video_vae.encode(image)})
+    if last_frame is not None:
+        image = resize_image(last_frame[:1], width, height, "center")
+        keyframe_images.append(image)
+        picture_labels.append(f"last_frame (exact frame {frame_count - 1})")
+        keyframes.append({"resolved_frame_index": frame_count - 1, "latent": video_vae.encode(image)})
+
+    real_ref_items: list[dict] = []
+    real_ref_blocks: list[dict] = []
+    video_labels: list[str] = []
+    audio_labels: list[str] = []
+
+    for index, image in enumerate(ref_image_values, 1):
+        resized, ref_width, ref_height = _resize_reference_image(image, width, height, ref_image_size)
+        encoded = video_vae.encode(resized)
+        real_ref_items.append({"type": "image", "data": resized})
+        real_ref_blocks.append(
+            {
+                "kind": "image",
+                "latent_h": ref_height // 16,
+                "latent_w": ref_width // 16,
+                "latent": encoded,
+            }
+        )
+        picture_labels.append(f"ref_image_{index}")
+
+    for index, (video_ordinal, frames) in enumerate(ref_video_entries, 1):
+        if frames.ndim != 4 or frames.shape[0] < 5:
+            raise ValueError(f"ref_video_{index} must contain at least 5 IMAGE frames")
+        input_frame_count = int(frames.shape[0])
+        if reference_video_policy == "official_2_to_15s" and not (2 * FPS <= input_frame_count <= 15 * FPS):
+            raise ValueError(
+                f"ref_video_{index} has {input_frame_count} frames; official guidance is 48-360 frames at 24fps"
+            )
+        source_height, source_width = int(frames.shape[1]), int(frames.shape[2])
+        canvas_width, canvas_height = adapt_canvas(source_width, source_height)
+        if source_width * source_height < canvas_width * canvas_height:
+            canvas_width = max(CANVAS_MULTIPLE, round(source_width / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
+            canvas_height = max(CANVAS_MULTIPLE, round(source_height / CANVAS_MULTIPLE) * CANVAS_MULTIPLE)
+        frames = resize_image(frames, canvas_width, canvas_height)
+        frames = frames[:frame_count]
+        aligned_count = align_frame_count_down(int(frames.shape[0]))
+        if aligned_count < 5:
+            raise ValueError(f"ref_video_{index} is too short after 17n+5 alignment")
+        frames = frames[:aligned_count]
+        encoded_video = video_vae.encode(frames)
+
+        soundtrack = ref_video_audio_by_ordinal.get(video_ordinal)
+        encoded_soundtrack, soundtrack_t = None, 0
+        if soundtrack is not None:
+            encoded_soundtrack, soundtrack_t = _encode_reference_audio(audio_vae, soundtrack)
+            real_ref_items.append({"type": "audio"})
+            audio_labels.append(f"ref_video_audio_{video_ordinal}")
+        sample_indices = list(range(0, frames.shape[0], FPS // 2))
+        real_ref_items.append(
+            {
+                "type": "video",
+                "data": frames[sample_indices],
+                "timestamps": [sample_index / FPS for sample_index in sample_indices],
+            }
+        )
+        real_ref_blocks.append(
+            {
+                "kind": "video_audio" if soundtrack_t else "video",
+                "latent_t": int(encoded_video.shape[2]),
+                "latent_h": canvas_height // 16,
+                "latent_w": canvas_width // 16,
+                "ref_audio_t": soundtrack_t,
+                "latent": encoded_video,
+                "audio_latent": encoded_soundtrack,
+            }
+        )
+        video_labels.append(f"ref_video_{video_ordinal}")
+
+    encoded_source = None
+    source_audio_ordinal = 0
+    if drive_audio is not None:
+        encoded_source = fit_audio_latent(encode_audio_once(audio_vae, drive_audio), template_audio)
+        if add_source_as_reference:
+            real_ref_items.append({"type": "audio"})
+            real_ref_blocks.append(
+                {
+                    "kind": "audio",
+                    "ref_audio_t": int(encoded_source.shape[-1]),
+                    "audio_latent": encoded_source,
+                }
+            )
+            audio_labels.append("drive_audio (primary source)")
+            source_audio_ordinal = len(audio_labels)
+
+    for index, audio in enumerate(ref_audio_values, 1):
+        encoded_audio, audio_t = _encode_reference_audio(audio_vae, audio)
+        real_ref_items.append({"type": "audio"})
+        real_ref_blocks.append({"kind": "audio", "ref_audio_t": audio_t, "audio_latent": encoded_audio})
+        audio_labels.append(f"ref_audio_{index}")
+
+    has_refs = bool(real_ref_blocks)
+    resolved_task = resolve_task_type(task_type, first_frame, last_frame, has_refs)
+    counts = {"pictures": len(picture_labels), "videos": len(video_labels), "audios": len(audio_labels)}
+    conditioned_prompt, prompt_warnings = prepare_prompt(
+        prompt,
+        counts,
+        source_audio_ordinal=source_audio_ordinal,
+        prompt_primary_audio_ordinal=prompt_primary_audio_ordinal,
+        strict=strict_prompt_tags,
+    )
+
+    if keyframes and real_ref_blocks:
+        assert_hybrid_layout_contract()
+        ref_items = [{"type": "image", "data": image} for image in keyframe_images] + real_ref_items
+        refs = [
+            {"kind": HYBRID_KEYFRAME_SENTINEL, "latent": keyframe["latent"]}
+            for keyframe in keyframes
+        ] + real_ref_blocks
+        tokens = clip.tokenize(conditioned_prompt, minimax_ref_items=ref_items)
+    elif real_ref_blocks:
+        refs = real_ref_blocks
+        tokens = clip.tokenize(conditioned_prompt, minimax_ref_items=real_ref_items)
+    else:
+        refs = []
+        tokens = clip.tokenize(conditioned_prompt, images=keyframe_images)
+
+    conditioning = clip.encode_from_tokens_scheduled(tokens)
+    values = {}
+    if keyframes:
+        values.update({"minimax_keyframes": keyframes, "minimax_frame_count": frame_count})
+    if refs:
+        values["minimax_refs"] = refs
+    if values:
+        conditioning = node_helpers.conditioning_set_values(conditioning, values)
+
+    if mode == "lock_source":
+        latent = replace_audio_latent(latent, encoded_source, 0.0)
+    elif mode == "remix_source":
+        latent = replace_audio_latent(latent, encoded_source, audio_denoise_strength)
+
+    media_map = media_map_json(picture_labels, video_labels, audio_labels, source_audio_ordinal)
+    report_lines = [
+        f"task={resolved_task}",
+        f"audio_mode={mode}",
+        f"frames={frame_count} ({frame_count / FPS:.3f}s at 24fps)",
+        f"pictures={len(picture_labels)}, videos={len(video_labels)}, audios={len(audio_labels)}",
+        f"source_audio_tag={'<Audio ' + str(source_audio_ordinal) + '>' if source_audio_ordinal else 'none'}",
+    ]
+    report_lines.extend(f"warning: {warning}" for warning in prompt_warnings)
+    output_audio = final_audio if final_audio is not None else drive_audio
+    return conditioning, latent, output_audio, conditioned_prompt, media_map, "\n".join(report_lines)

--- a/core.py
+++ b/core.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+
+import torch
+import torchaudio
+
+import comfy.model_management
+import comfy.nested_tensor
+import comfy.utils
+
+
+CANVAS_MULTIPLE = 32
+BASE_SHORT_EDGE = 768
+MAX_PIXELS = 768 * 1344
+REF_IMAGE_SHORT_EDGE = 2048
+FPS = 24
+AUDIO_LATENT_FPS = 40
+MIN_TRAINED_FRAMES = 124
+MAX_TRAINED_FRAMES = 362
+
+
+def align_frame_count(frame_count: int) -> int:
+    """Snap up to MiniMax H3's 17n+5 frame grid."""
+    frame_count = max(5, int(frame_count))
+    return frame_count + ((5 - frame_count) % 17)
+
+
+def align_frame_count_down(frame_count: int) -> int:
+    frame_count = int(frame_count)
+    return frame_count - ((frame_count - 5) % 17)
+
+
+def video_latent_t(frame_count: int) -> int:
+    return 2 if frame_count <= 5 else ((frame_count - 5) // 17) * 5 + 2
+
+
+def temporal_shape(length: int) -> tuple[int, int, int]:
+    frame_count = align_frame_count(length)
+    duration = frame_count / FPS
+    return frame_count, video_latent_t(frame_count), round(duration * AUDIO_LATENT_FPS)
+
+
+def adapt_canvas(width: int, height: int) -> tuple[int, int]:
+    if width <= 0 or height <= 0:
+        raise ValueError("Width and height must be positive")
+    ratio = width / height
+    if ratio >= 1.0:
+        nominal_width, nominal_height = BASE_SHORT_EDGE * ratio, BASE_SHORT_EDGE
+    else:
+        nominal_width, nominal_height = BASE_SHORT_EDGE, BASE_SHORT_EDGE / ratio
+    if nominal_width * nominal_height > MAX_PIXELS:
+        scale = math.sqrt(MAX_PIXELS / (nominal_width * nominal_height))
+        nominal_width *= scale
+        nominal_height *= scale
+    return (
+        max(CANVAS_MULTIPLE, round(nominal_width / CANVAS_MULTIPLE) * CANVAS_MULTIPLE),
+        max(CANVAS_MULTIPLE, round(nominal_height / CANVAS_MULTIPLE) * CANVAS_MULTIPLE),
+    )
+
+
+def resize_image(image: torch.Tensor, width: int, height: int, crop: str = "disabled") -> torch.Tensor:
+    if image.ndim != 4:
+        raise ValueError(f"Expected IMAGE [B,H,W,C], got {tuple(image.shape)}")
+    samples = image[..., :3].movedim(-1, 1)
+    samples = comfy.utils.common_upscale(samples, width, height, "lanczos", crop)
+    return samples.movedim(1, -1)
+
+
+def empty_av_latent(width: int, height: int, length: int) -> tuple[dict, int]:
+    if width % 32 or height % 32:
+        raise ValueError("MiniMax H3 width and height must be divisible by 32")
+    frame_count, latent_t, audio_t = temporal_shape(length)
+    device = comfy.model_management.intermediate_device()
+    video = torch.zeros((1, 24, latent_t, height // 16, width // 16), device=device)
+    audio = torch.zeros((1, 32, 2, audio_t), device=device)
+    return {"samples": comfy.nested_tensor.NestedTensor((video, audio))}, frame_count
+
+
+def nested_av_parts(av_latent: dict) -> tuple[torch.Tensor, torch.Tensor]:
+    if not isinstance(av_latent, dict) or "samples" not in av_latent:
+        raise ValueError("Expected a MiniMax H3 joint AV LATENT")
+    samples = av_latent["samples"]
+    if not getattr(samples, "is_nested", False):
+        raise ValueError("Expected a nested MiniMax H3 joint video/audio latent")
+    parts = tuple(samples.unbind())
+    if len(parts) != 2:
+        raise ValueError(f"Expected exactly two AV latent parts, got {len(parts)}")
+    video, audio = parts
+    if video.ndim != 5 or audio.ndim != 4:
+        raise ValueError(
+            "Unexpected MiniMax H3 AV latent layout: "
+            f"video={tuple(video.shape)}, audio={tuple(audio.shape)}"
+        )
+    if video.shape[0] != 1 or audio.shape[0] != 1:
+        raise ValueError("MiniMax H3 currently supports batch size 1 only")
+    return video, audio
+
+
+def validate_audio(audio: dict, name: str = "audio") -> tuple[torch.Tensor, int]:
+    if not isinstance(audio, dict):
+        raise ValueError(f"{name} must be a connected AUDIO value")
+    waveform = audio.get("waveform")
+    sample_rate = audio.get("sample_rate")
+    if not isinstance(waveform, torch.Tensor) or sample_rate is None:
+        raise ValueError(f"{name} is missing waveform or sample_rate")
+    if waveform.ndim != 3:
+        raise ValueError(f"{name} must use [batch,channels,samples], got {tuple(waveform.shape)}")
+    if waveform.shape[0] < 1 or waveform.shape[1] < 1 or waveform.shape[2] < 1:
+        raise ValueError(f"{name} is empty")
+    if waveform.shape[0] != 1:
+        raise ValueError(f"{name} must have batch size 1 for MiniMax H3")
+    return waveform, int(sample_rate)
+
+
+def encode_audio_once(audio_vae, audio: dict) -> torch.Tensor:
+    waveform, sample_rate = validate_audio(audio)
+    vae_sample_rate = int(getattr(audio_vae, "audio_sample_rate", 32000))
+    if sample_rate != vae_sample_rate:
+        waveform = torchaudio.functional.resample(waveform, sample_rate, vae_sample_rate)
+    latent = audio_vae.encode(waveform[:1].movedim(1, -1))
+    if not isinstance(latent, torch.Tensor) or latent.ndim != 4:
+        raise ValueError("The audio VAE did not return [B,C,stereo,T] latent data")
+    return latent
+
+
+def fit_audio_latent(encoded_audio: torch.Tensor, template_audio: torch.Tensor) -> torch.Tensor:
+    if encoded_audio.ndim != 4 or template_audio.ndim != 4:
+        raise ValueError("MiniMax H3 audio latents must use [B,C,stereo,T]")
+    if encoded_audio.shape[1:-1] != template_audio.shape[1:-1]:
+        raise ValueError(
+            "Audio VAE latent layout mismatch: "
+            f"got {tuple(encoded_audio.shape)}, target {tuple(template_audio.shape)}"
+        )
+    if encoded_audio.shape[0] != template_audio.shape[0]:
+        if encoded_audio.shape[0] == 1:
+            encoded_audio = encoded_audio.expand(template_audio.shape[0], -1, -1, -1)
+        else:
+            raise ValueError("Audio latent batch cannot be matched to the AV latent")
+    target_t = template_audio.shape[-1]
+    if encoded_audio.shape[-1] > target_t:
+        encoded_audio = encoded_audio[..., :target_t]
+    elif encoded_audio.shape[-1] < target_t:
+        padding = encoded_audio.new_zeros((*encoded_audio.shape[:-1], target_t - encoded_audio.shape[-1]))
+        encoded_audio = torch.cat((encoded_audio, padding), dim=-1)
+    return encoded_audio.to(device=template_audio.device, dtype=template_audio.dtype)
+
+
+def sorted_autogrow_items(values: Mapping | None) -> list[tuple[int, object]]:
+    if not values:
+        return []
+
+    def sort_key(item):
+        key = str(item[0])
+        try:
+            return int(key.rsplit("_", 1)[-1])
+        except ValueError:
+            return 10_000
+
+    output = []
+    for key, value in sorted(values.items(), key=sort_key):
+        if value is None:
+            continue
+        try:
+            ordinal = int(str(key).rsplit("_", 1)[-1])
+        except ValueError:
+            ordinal = len(output) + 1
+        output.append((ordinal, value))
+    return output
+
+
+def sorted_autogrow_values(values: Mapping | None) -> list:
+    return [value for _, value in sorted_autogrow_items(values)]
+
+
+def split_noise_masks(av_latent: dict, video: torch.Tensor, audio: torch.Tensor):
+    masks = av_latent.get("noise_mask")
+    if masks is None:
+        return None, None
+    if getattr(masks, "is_nested", False):
+        parts = tuple(masks.unbind())
+        if len(parts) == 2:
+            return parts
+    # A legacy video-only mask must never be silently discarded.
+    if isinstance(masks, torch.Tensor):
+        return masks, None
+    raise ValueError("Unsupported AV noise_mask layout")
+
+
+def replace_audio_latent(av_latent: dict, encoded_audio: torch.Tensor, denoise_strength: float) -> dict:
+    video, template_audio = nested_av_parts(av_latent)
+    fitted = fit_audio_latent(encoded_audio, template_audio)
+    video_mask, _ = split_noise_masks(av_latent, video, template_audio)
+    if video_mask is None:
+        video_mask = torch.ones_like(video)
+    audio_mask = torch.full_like(fitted, float(denoise_strength))
+    output = av_latent.copy()
+    output["samples"] = comfy.nested_tensor.NestedTensor((video, fitted))
+    output["noise_mask"] = comfy.nested_tensor.NestedTensor((video_mask, audio_mask))
+    return output

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,7 @@
+# Example
+
+`audio_lock_api.json` 是 API prompt 格式示例，展示完整链路：音频窗口、统一条件、H3
+采样、联合解码、同步裁切和 MP4 输出。
+
+使用前把四个 loader 中的模型文件名和 `LoadAudio.audio` 改为本机实际文件。示例最后使用
+VideoHelperSuite 的 `VHS_VideoCombine`；核心 T8 节点本身不依赖 VideoHelperSuite。

--- a/examples/audio_lock_api.json
+++ b/examples/audio_lock_api.json
@@ -1,0 +1,138 @@
+{
+  "1": {
+    "inputs": {"audio": "replace_with_source_audio.wav"},
+    "class_type": "LoadAudio",
+    "_meta": {"title": "Load source audio"}
+  },
+  "2": {
+    "inputs": {
+      "scene_start_seconds": 0.0,
+      "scene_duration_seconds": 5.0,
+      "warmup_seconds": 0.0,
+      "cooldown_seconds": 0.0,
+      "ensure_minimum_context": true,
+      "audio": ["1", 0]
+    },
+    "class_type": "MiniMaxH3AudioWindowT8",
+    "_meta": {"title": "Align source audio to H3 context"}
+  },
+  "3": {
+    "inputs": {"vae_name": "replace_with_minimax_h3_video_vae.safetensors"},
+    "class_type": "VAELoader",
+    "_meta": {"title": "Load H3 video VAE"}
+  },
+  "4": {
+    "inputs": {"vae_name": "replace_with_minimax_h3_audio_vae.safetensors"},
+    "class_type": "VAELoader",
+    "_meta": {"title": "Load H3 audio VAE"}
+  },
+  "5": {
+    "inputs": {
+      "clip_name": "replace_with_qwen3vl_minimax_h3.safetensors",
+      "type": "minimax",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {"title": "Load H3 CLIP"}
+  },
+  "6": {
+    "inputs": {
+      "unet_name": "replace_with_native_minimax_h3_diffusion_model.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {"title": "Load native H3 diffusion model"}
+  },
+  "7": {
+    "inputs": {"shift_video": 12.0, "shift_audio": 3.0, "model": ["6", 0]},
+    "class_type": "MiniMaxH3SigmaShift",
+    "_meta": {"title": "Native H3 sigma shifts"}
+  },
+  "8": {
+    "inputs": {
+      "prompt": "A singer performs in perfect synchronization with <Audio 1>; natural facial motion and precise lip movement.",
+      "width": 1344,
+      "height": 768,
+      "length": ["2", 1],
+      "task_type": "auto",
+      "audio_mode": "lock_source",
+      "audio_denoise_strength": 0.35,
+      "add_source_as_reference": true,
+      "prompt_primary_audio_ordinal": 1,
+      "strict_prompt_tags": true,
+      "ref_image_size": "match",
+      "reference_video_policy": "official_2_to_15s",
+      "clip": ["5", 0],
+      "video_vae": ["3", 0],
+      "audio_vae": ["4", 0],
+      "drive_audio": ["2", 0]
+    },
+    "class_type": "MiniMaxH3AudioConditioningT8",
+    "_meta": {"title": "T8 H3 audio lock conditioning"}
+  },
+  "9": {
+    "inputs": {"noise_seed": 123456789},
+    "class_type": "RandomNoise",
+    "_meta": {"title": "Noise"}
+  },
+  "10": {
+    "inputs": {"model": ["7", 0], "conditioning": ["8", 0]},
+    "class_type": "BasicGuider",
+    "_meta": {"title": "Basic guider"}
+  },
+  "11": {
+    "inputs": {"sampler_name": "res_multistep"},
+    "class_type": "KSamplerSelect",
+    "_meta": {"title": "Sampler"}
+  },
+  "12": {
+    "inputs": {"scheduler": "simple", "steps": 20, "denoise": 1.0, "model": ["7", 0]},
+    "class_type": "BasicScheduler",
+    "_meta": {"title": "Sigmas"}
+  },
+  "13": {
+    "inputs": {
+      "noise": ["9", 0],
+      "guider": ["10", 0],
+      "sampler": ["11", 0],
+      "sigmas": ["12", 0],
+      "latent_image": ["8", 1]
+    },
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {"title": "Sample H3 AV latent"}
+  },
+  "14": {
+    "inputs": {"av_latent": ["13", 0], "video_vae": ["3", 0], "audio_vae": ["4", 0]},
+    "class_type": "MiniMaxH3AVDecodeT8",
+    "_meta": {"title": "Decode H3 video and generated audio"}
+  },
+  "15": {
+    "inputs": {
+      "start_seconds": ["2", 2],
+      "duration_seconds": ["2", 3],
+      "fps": 24.0,
+      "frames": ["14", 0],
+      "audio": ["8", 2]
+    },
+    "class_type": "MiniMaxH3OutputTrimT8",
+    "_meta": {"title": "Restore exact requested scene"}
+  },
+  "16": {
+    "inputs": {
+      "frame_rate": 24,
+      "loop_count": 0,
+      "filename_prefix": "MiniMaxH3_Audio_T8",
+      "format": "video/h264-mp4",
+      "pix_fmt": "yuv420p",
+      "crf": 19,
+      "save_metadata": true,
+      "trim_to_audio": false,
+      "pingpong": false,
+      "save_output": true,
+      "images": ["15", 0],
+      "audio": ["15", 1]
+    },
+    "class_type": "VHS_VideoCombine",
+    "_meta": {"title": "Save synchronized MP4"}
+  }
+}

--- a/features.json
+++ b/features.json
@@ -1,0 +1,28 @@
+{
+  "native_h3_contract": {
+    "fps": 24,
+    "frame_grid": "17n+5",
+    "trained_frame_range": [124, 362],
+    "max_pixel_area": 1032192,
+    "batch_size": 1
+  },
+  "audio_modes": ["native", "reference_only", "lock_source", "remix_source"],
+  "task_modes": ["T2VA", "I2VA", "FL2VA", "L2VA", "Ref2VA", "Hybrid"],
+  "nodes": [
+    "MiniMaxH3AudioConditioningT8",
+    "MiniMaxH3AudioLatentControlT8",
+    "MiniMaxH3DurationPlannerT8",
+    "MiniMaxH3AudioWindowT8",
+    "MiniMaxH3PromptTagsT8",
+    "MiniMaxH3AVDecodeT8",
+    "MiniMaxH3AudioMixT8",
+    "MiniMaxH3OutputTrimT8",
+    "MiniMaxH3PreflightT8"
+  ],
+  "reference_limits": {
+    "pictures": 9,
+    "videos": 3,
+    "standalone_audios": 3,
+    "reference_video_guidance_seconds": [2, 15]
+  }
+}

--- a/meta.json
+++ b/meta.json
@@ -1,0 +1,10 @@
+{
+  "name": "minimax-h3-audio-T8",
+  "version": "1.0.0",
+  "category": "T8/MiniMax H3/Audio",
+  "license": "GPL-3.0-or-later",
+  "validated_on": "2026-08-05",
+  "validated_comfyui_commit": "e377e263049f9338b4d12a3dd417b36ae62948ff",
+  "python": "3.10+",
+  "external_runtime_dependencies": []
+}

--- a/nodes.py
+++ b/nodes.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from comfy_api.latest import ComfyExtension, io
+
+from .audio_ops import decode_av_latent, inject_audio_latent, mix_audio, trim_av_output
+from .conditioning import build_conditioning
+from .preflight import run_preflight
+from .prompt_tags import prepare_prompt
+from .timing import make_timing_plan, window_audio
+
+
+CATEGORY = "T8/MiniMax H3/Audio"
+MAX_RESOLUTION = 16384
+
+
+class MiniMaxH3AudioConditioningT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3AudioConditioningT8",
+            display_name="MiniMax H3 Audio Conditioning (T8)",
+            description="Unified native H3 T2VA/I2VA/FL2VA/L2VA/Ref2VA/hybrid conditioning with correct media tags and source-audio control.",
+            category=CATEGORY,
+            inputs=[
+                io.Clip.Input("clip", tooltip="Native MiniMax H3 Qwen3-VL CLIP."),
+                io.Vae.Input("video_vae", tooltip="MiniMax H3 video VAE."),
+                io.Vae.Input("audio_vae", tooltip="MiniMax H3 audio VAE."),
+                io.String.Input("prompt", multiline=True, dynamic_prompts=True),
+                io.Int.Input("width", default=1344, min=32, max=MAX_RESOLUTION, step=32),
+                io.Int.Input("height", default=768, min=32, max=MAX_RESOLUTION, step=32),
+                io.Int.Input("length", default=124, min=5, max=3600, step=17, tooltip="24fps; snapped up to the 17n+5 H3 grid."),
+                io.Combo.Input("task_type", options=["auto", "T2VA", "I2VA", "FL2VA", "L2VA", "Ref2VA", "Hybrid"], default="auto"),
+                io.Combo.Input("audio_mode", options=["lock_source", "remix_source", "reference_only", "native"], default="lock_source", tooltip="lock_source preserves source latent; remix_source denoises it; reference_only/native generate target audio."),
+                io.Float.Input("audio_denoise_strength", default=0.35, min=0.0, max=1.0, step=0.01, advanced=True),
+                io.Boolean.Input("add_source_as_reference", default=True, tooltip="Presents drive_audio to Qwen/DiT as an official <Audio N> reference."),
+                io.Int.Input("prompt_primary_audio_ordinal", default=1, min=0, max=9, step=1, tooltip="Prompt audio ordinal intended as the primary source; remapped after video soundtracks. Use 0 to disable.", advanced=True),
+                io.Boolean.Input("strict_prompt_tags", default=True, advanced=True),
+                io.Combo.Input("ref_image_size", options=["match", "max"], default="match", advanced=True),
+                io.Combo.Input("reference_video_policy", options=["official_2_to_15s", "model_minimum"], default="official_2_to_15s", advanced=True),
+                io.Audio.Input("drive_audio", optional=True),
+                io.Audio.Input("final_audio", optional=True, tooltip="Optional clean/stem track passed through for final mux; defaults to drive_audio."),
+                io.Image.Input("first_frame", optional=True),
+                io.Image.Input("last_frame", optional=True),
+                io.Autogrow.Input("ref_images", optional=True, template=io.Autogrow.TemplatePrefix(input=io.Image.Input("ref_image"), prefix="ref_image_", min=0, max=9)),
+                io.Autogrow.Input("ref_videos", optional=True, template=io.Autogrow.TemplatePrefix(input=io.Image.Input("ref_video", tooltip="IMAGE frame batch at 24fps."), prefix="ref_video_", min=0, max=3)),
+                io.Autogrow.Input("ref_video_audios", optional=True, template=io.Autogrow.TemplatePrefix(input=io.Audio.Input("ref_video_audio"), prefix="ref_video_audio_", min=0, max=3)),
+                io.Autogrow.Input("ref_audios", optional=True, template=io.Autogrow.TemplatePrefix(input=io.Audio.Input("ref_audio"), prefix="ref_audio_", min=0, max=3)),
+            ],
+            outputs=[
+                io.Conditioning.Output(display_name="positive"),
+                io.Latent.Output(display_name="av_latent"),
+                io.Audio.Output(display_name="mux_audio"),
+                io.String.Output(display_name="conditioned_prompt"),
+                io.String.Output(display_name="media_map_json"),
+                io.String.Output(display_name="report"),
+            ],
+        )
+
+    @classmethod
+    def execute(cls, clip, video_vae, audio_vae, prompt, width, height, length, task_type, audio_mode,
+                audio_denoise_strength, add_source_as_reference, prompt_primary_audio_ordinal,
+                strict_prompt_tags, ref_image_size, reference_video_policy, drive_audio=None,
+                final_audio=None, first_frame=None, last_frame=None, ref_images=None, ref_videos=None,
+                ref_video_audios=None, ref_audios=None):
+        return io.NodeOutput(*build_conditioning(
+            clip, video_vae, audio_vae, prompt, width, height, length, task_type, audio_mode,
+            audio_denoise_strength, add_source_as_reference, prompt_primary_audio_ordinal,
+            strict_prompt_tags, ref_image_size, reference_video_policy, drive_audio, final_audio,
+            first_frame, last_frame, ref_images, ref_videos, ref_video_audios, ref_audios,
+        ))
+
+
+class MiniMaxH3AudioLatentControlT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3AudioLatentControlT8",
+            display_name="MiniMax H3 Audio Latent Control (T8)",
+            description="Injects source audio once and preserves an existing video noise mask.",
+            category=CATEGORY,
+            inputs=[
+                io.Latent.Input("av_latent"), io.Audio.Input("source_audio"), io.Vae.Input("audio_vae"),
+                io.Combo.Input("mode", options=["lock", "remix"], default="lock"),
+                io.Float.Input("strength", default=0.35, min=0.0, max=1.0, step=0.01),
+            ],
+            outputs=[io.Latent.Output(display_name="av_latent"), io.Audio.Output(display_name="source_audio")],
+        )
+
+    @classmethod
+    def execute(cls, av_latent, source_audio, audio_vae, mode, strength):
+        return io.NodeOutput(*inject_audio_latent(av_latent, source_audio, audio_vae, mode, strength))
+
+
+class MiniMaxH3DurationPlannerT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3DurationPlannerT8",
+            display_name="MiniMax H3 Duration Planner (T8)",
+            category=CATEGORY,
+            inputs=[
+                io.Float.Input("scene_start_seconds", default=0.0, min=0.0, max=86400.0, step=0.01),
+                io.Float.Input("scene_duration_seconds", default=5.0, min=0.04, max=900.0, step=0.01),
+                io.Float.Input("warmup_seconds", default=0.0, min=0.0, max=60.0, step=0.01),
+                io.Float.Input("cooldown_seconds", default=0.0, min=0.0, max=60.0, step=0.01),
+                io.Boolean.Input("ensure_minimum_context", default=True),
+                io.Float.Input("source_duration_seconds", default=0.0, min=0.0, max=86400.0, step=0.01, advanced=True, tooltip="0 means unknown; the Audio Window node reads it from AUDIO."),
+            ],
+            outputs=[
+                io.Int.Output("length"), io.Float.Output("render_duration_seconds"),
+                io.Float.Output("source_slice_start_seconds"), io.Float.Output("source_slice_duration_seconds"),
+                io.Float.Output("final_trim_start_seconds"), io.Float.Output("final_duration_seconds"),
+                io.String.Output("prompt_timing_note"), io.String.Output("report_json"),
+            ],
+        )
+
+    @classmethod
+    def execute(cls, scene_start_seconds, scene_duration_seconds, warmup_seconds, cooldown_seconds,
+                ensure_minimum_context, source_duration_seconds):
+        plan = make_timing_plan(scene_start_seconds, scene_duration_seconds, warmup_seconds,
+                                cooldown_seconds, ensure_minimum_context, source_duration_seconds)
+        return io.NodeOutput(plan.frame_count, plan.render_duration_seconds, plan.source_slice_start_seconds,
+                             plan.source_slice_duration_seconds, plan.final_trim_start_seconds,
+                             plan.final_duration_seconds, plan.prompt_note(), plan.report())
+
+
+class MiniMaxH3AudioWindowT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3AudioWindowT8",
+            display_name="MiniMax H3 Audio Window (T8)",
+            description="Slices/pads source AUDIO to an aligned H3 context and returns exact final trim metadata.",
+            category=CATEGORY,
+            inputs=[
+                io.Audio.Input("audio"),
+                io.Float.Input("scene_start_seconds", default=0.0, min=0.0, max=86400.0, step=0.01),
+                io.Float.Input("scene_duration_seconds", default=5.0, min=0.04, max=900.0, step=0.01),
+                io.Float.Input("warmup_seconds", default=0.0, min=0.0, max=60.0, step=0.01),
+                io.Float.Input("cooldown_seconds", default=0.0, min=0.0, max=60.0, step=0.01),
+                io.Boolean.Input("ensure_minimum_context", default=True),
+            ],
+            outputs=[io.Audio.Output("context_audio"), io.Int.Output("length"),
+                     io.Float.Output("final_trim_start_seconds"), io.Float.Output("final_duration_seconds"),
+                     io.String.Output("prompt_timing_note"), io.String.Output("report_json")],
+        )
+
+    @classmethod
+    def execute(cls, audio, scene_start_seconds, scene_duration_seconds, warmup_seconds, cooldown_seconds,
+                ensure_minimum_context):
+        source_duration = audio["waveform"].shape[-1] / int(audio["sample_rate"])
+        plan = make_timing_plan(scene_start_seconds, scene_duration_seconds, warmup_seconds,
+                                cooldown_seconds, ensure_minimum_context, source_duration)
+        return io.NodeOutput(window_audio(audio, plan), plan.frame_count, plan.final_trim_start_seconds,
+                             plan.final_duration_seconds, plan.prompt_note(), plan.report())
+
+
+class MiniMaxH3PromptTagsT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3PromptTagsT8", display_name="MiniMax H3 Prompt Tags (T8)", category=CATEGORY,
+            inputs=[
+                io.String.Input("prompt", multiline=True, dynamic_prompts=True),
+                io.Int.Input("picture_count", default=0, min=0, max=11),
+                io.Int.Input("video_count", default=0, min=0, max=3),
+                io.Int.Input("audio_count", default=1, min=0, max=9),
+                io.Int.Input("source_audio_ordinal", default=1, min=0, max=9),
+                io.Int.Input("prompt_primary_audio_ordinal", default=1, min=0, max=9),
+                io.Boolean.Input("strict", default=True),
+            ], outputs=[io.String.Output("prompt"), io.String.Output("report")],
+        )
+
+    @classmethod
+    def execute(cls, prompt, picture_count, video_count, audio_count, source_audio_ordinal,
+                prompt_primary_audio_ordinal, strict):
+        normalized, warnings = prepare_prompt(prompt, {"pictures": picture_count, "videos": video_count,
+                                                       "audios": audio_count}, source_audio_ordinal,
+                                              prompt_primary_audio_ordinal, strict)
+        return io.NodeOutput(normalized, "OK" if not warnings else "\n".join(warnings))
+
+
+class MiniMaxH3AVDecodeT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3AVDecodeT8", display_name="MiniMax H3 AV Decode (T8)", category=CATEGORY,
+            inputs=[io.Latent.Input("av_latent"), io.Vae.Input("video_vae"), io.Vae.Input("audio_vae")],
+            outputs=[io.Image.Output("frames"), io.Audio.Output("generated_audio"),
+                     io.Latent.Output("video_latent"), io.Latent.Output("audio_latent")],
+        )
+
+    @classmethod
+    def execute(cls, av_latent, video_vae, audio_vae):
+        return io.NodeOutput(*decode_av_latent(av_latent, video_vae, audio_vae))
+
+
+class MiniMaxH3AudioMixT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3AudioMixT8", display_name="MiniMax H3 Audio Mix (T8)", category=CATEGORY,
+            inputs=[
+                io.Audio.Input("source_audio"), io.Audio.Input("generated_audio"),
+                io.Float.Input("source_gain_db", default=0.0, min=-60.0, max=24.0, step=0.1),
+                io.Float.Input("generated_gain_db", default=-6.0, min=-60.0, max=24.0, step=0.1),
+                io.Float.Input("duck_generated", default=0.5, min=0.0, max=1.0, step=0.01),
+                io.Combo.Input("output_sample_rate", options=["source", "generated", "48000", "44100", "32000"], default="source"),
+                io.Float.Input("peak_limit_dbfs", default=-1.0, min=-12.0, max=0.0, step=0.1),
+            ], outputs=[io.Audio.Output("mixed_audio")],
+        )
+
+    @classmethod
+    def execute(cls, source_audio, generated_audio, source_gain_db, generated_gain_db,
+                duck_generated, output_sample_rate, peak_limit_dbfs):
+        return io.NodeOutput(mix_audio(source_audio, generated_audio, source_gain_db, generated_gain_db,
+                                       duck_generated, output_sample_rate, peak_limit_dbfs))
+
+
+class MiniMaxH3OutputTrimT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3OutputTrimT8", display_name="MiniMax H3 Output Trim (T8)", category=CATEGORY,
+            description="Applies Duration Planner trim metadata to decoded IMAGE frames and optional AUDIO.",
+            inputs=[
+                io.Image.Input("frames"),
+                io.Float.Input("start_seconds", default=0.0, min=0.0, max=900.0, step=0.001),
+                io.Float.Input("duration_seconds", default=5.0, min=0.04, max=900.0, step=0.001),
+                io.Float.Input("fps", default=24.0, min=1.0, max=240.0, step=0.001, advanced=True),
+                io.Audio.Input("audio", optional=True),
+            ],
+            outputs=[io.Image.Output("frames"), io.Audio.Output("audio"), io.String.Output("report_json")],
+        )
+
+    @classmethod
+    def execute(cls, frames, start_seconds, duration_seconds, fps, audio=None):
+        return io.NodeOutput(*trim_av_output(frames, start_seconds, duration_seconds, audio, fps))
+
+
+class MiniMaxH3PreflightT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3PreflightT8", display_name="MiniMax H3 Preflight (T8)", category=CATEGORY,
+            inputs=[
+                io.Int.Input("width", default=1344, min=32, max=MAX_RESOLUTION, step=32),
+                io.Int.Input("height", default=768, min=32, max=MAX_RESOLUTION, step=32),
+                io.Int.Input("length", default=124, min=5, max=3600),
+                io.Combo.Input("audio_mode", options=["lock_source", "remix_source", "reference_only", "native"], default="lock_source"),
+                io.Model.Input("model", optional=True), io.Vae.Input("video_vae", optional=True),
+                io.Vae.Input("audio_vae", optional=True), io.Audio.Input("drive_audio", optional=True),
+                io.Autogrow.Input("ref_images", optional=True, template=io.Autogrow.TemplatePrefix(input=io.Image.Input("ref_image"), prefix="ref_image_", min=0, max=9)),
+                io.Autogrow.Input("ref_videos", optional=True, template=io.Autogrow.TemplatePrefix(input=io.Image.Input("ref_video"), prefix="ref_video_", min=0, max=3)),
+                io.Autogrow.Input("ref_audios", optional=True, template=io.Autogrow.TemplatePrefix(input=io.Audio.Input("ref_audio"), prefix="ref_audio_", min=0, max=3)),
+            ], outputs=[io.Boolean.Output("ready"), io.Int.Output("warning_count"), io.String.Output("report_json")],
+        )
+
+    @classmethod
+    def execute(cls, width, height, length, audio_mode, model=None, video_vae=None, audio_vae=None,
+                drive_audio=None, ref_images=None, ref_videos=None, ref_audios=None):
+        return io.NodeOutput(*run_preflight(width, height, length, audio_mode, model, video_vae, audio_vae,
+                                            drive_audio, ref_images, ref_videos, ref_audios))
+
+
+class MiniMaxH3AudioT8Extension(ComfyExtension):
+    async def get_node_list(self):
+        return [MiniMaxH3AudioConditioningT8, MiniMaxH3AudioLatentControlT8,
+                MiniMaxH3DurationPlannerT8, MiniMaxH3AudioWindowT8, MiniMaxH3PromptTagsT8,
+                MiniMaxH3AVDecodeT8, MiniMaxH3AudioMixT8, MiniMaxH3OutputTrimT8,
+                MiniMaxH3PreflightT8]
+
+
+def comfy_entrypoint():
+    return MiniMaxH3AudioT8Extension()

--- a/preflight.py
+++ b/preflight.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+
+import torch
+
+from comfy.ldm.minimax.model import MiniMaxH3Model
+
+from .core import (
+    MAX_PIXELS,
+    MAX_TRAINED_FRAMES,
+    MIN_TRAINED_FRAMES,
+    align_frame_count,
+    sorted_autogrow_values,
+    validate_audio,
+)
+
+
+def run_preflight(
+    width: int,
+    height: int,
+    length: int,
+    audio_mode: str,
+    model=None,
+    video_vae=None,
+    audio_vae=None,
+    drive_audio=None,
+    ref_images=None,
+    ref_videos=None,
+    ref_audios=None,
+):
+    errors: list[str] = []
+    warnings: list[str] = []
+    facts: dict[str, object] = {}
+
+    if width <= 0 or height <= 0 or width % 32 or height % 32:
+        errors.append("width and height must be positive multiples of 32")
+    pixels = width * height
+    facts["pixels"] = pixels
+    if pixels > MAX_PIXELS:
+        errors.append(f"canvas has {pixels:,} pixels; native H3 cap is {MAX_PIXELS:,}")
+    aligned = align_frame_count(length)
+    facts["aligned_frames"] = aligned
+    if aligned != length:
+        warnings.append(f"length {length} will snap up to {aligned} on the 17n+5 grid")
+    if not MIN_TRAINED_FRAMES <= aligned <= MAX_TRAINED_FRAMES:
+        warnings.append(
+            f"{aligned} frames is outside the approximately trained {MIN_TRAINED_FRAMES}-{MAX_TRAINED_FRAMES} range"
+        )
+
+    if model is not None:
+        diffusion_model = getattr(getattr(model, "model", None), "diffusion_model", None)
+        if not isinstance(diffusion_model, MiniMaxH3Model):
+            errors.append("model is not a native ComfyUI MiniMax H3 diffusion model")
+    if video_vae is not None and hasattr(video_vae, "audio_sample_rate"):
+        warnings.append("video_vae exposes an audio sample rate; verify the video and audio VAEs are not swapped")
+    if audio_vae is not None:
+        facts["audio_vae_sample_rate"] = int(getattr(audio_vae, "audio_sample_rate", 32000))
+
+    if audio_mode != "native" and drive_audio is None:
+        errors.append(f"audio mode {audio_mode} requires drive_audio")
+    if drive_audio is not None:
+        try:
+            waveform, sample_rate = validate_audio(drive_audio, "drive_audio")
+            facts["drive_audio_sample_rate"] = sample_rate
+            facts["drive_audio_duration_seconds"] = waveform.shape[-1] / sample_rate
+            if not torch.isfinite(waveform).all():
+                errors.append("drive_audio contains NaN or infinite samples")
+            else:
+                peak = float(waveform.abs().max())
+                rms = float(torch.sqrt(torch.mean(waveform.float().square())))
+                facts["drive_audio_peak"] = peak
+                facts["drive_audio_rms"] = rms
+                if peak > 1.0:
+                    warnings.append(f"drive_audio peak {peak:.3f} exceeds 0 dBFS and may clip")
+                if rms < 1e-4:
+                    warnings.append("drive_audio is effectively silent")
+        except ValueError as error:
+            errors.append(str(error))
+
+    pictures = sorted_autogrow_values(ref_images)
+    videos = sorted_autogrow_values(ref_videos)
+    audios = sorted_autogrow_values(ref_audios)
+    facts.update({"reference_images": len(pictures), "reference_videos": len(videos), "reference_audios": len(audios)})
+    if len(pictures) > 9 or len(videos) > 3 or len(audios) > 3:
+        errors.append("reference counts exceed H3 limits (9 pictures / 3 videos / 3 audios)")
+    for index, frames in enumerate(videos, 1):
+        if not isinstance(frames, torch.Tensor) or frames.ndim != 4:
+            errors.append(f"ref_video_{index} is not an IMAGE frame batch")
+        elif not 48 <= frames.shape[0] <= 360:
+            warnings.append(f"ref_video_{index} has {frames.shape[0]} frames; official guidance is 48-360 at 24fps")
+
+    ready = not errors
+    report = json.dumps(
+        {"ready": ready, "errors": errors, "warnings": warnings, "facts": facts},
+        ensure_ascii=False,
+        indent=2,
+    )
+    return ready, len(warnings), report

--- a/prompt_tags.py
+++ b/prompt_tags.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import json
+import re
+
+
+MEDIA_TAG_RE = re.compile(
+    r"<\s*(Image|Picture|Video|Audio)\s*(\d+)\s*>|"
+    r"(?<![\w<])(Image|Picture|Video|Audio)\s*#?\s*(\d+)\b(?!\s*>)",
+    re.IGNORECASE,
+)
+OFFICIAL_TAG_RE = re.compile(r"<(Picture|Video|Audio)\s+(\d+)>", re.IGNORECASE)
+
+
+def canonicalize_media_tags(prompt: str) -> str:
+    def replacement(match: re.Match) -> str:
+        media_type = (match.group(1) or match.group(3)).lower()
+        ordinal = int(match.group(2) or match.group(4))
+        official_type = "Picture" if media_type in {"image", "picture"} else media_type.title()
+        return f"<{official_type} {ordinal}>"
+
+    return MEDIA_TAG_RE.sub(replacement, prompt or "")
+
+
+def prepare_prompt(
+    prompt: str,
+    counts: dict[str, int],
+    source_audio_ordinal: int = 0,
+    prompt_primary_audio_ordinal: int = 1,
+    strict: bool = True,
+) -> tuple[str, list[str]]:
+    normalized = canonicalize_media_tags(prompt)
+    if source_audio_ordinal > 0 and prompt_primary_audio_ordinal > 0:
+        primary = re.compile(rf"<Audio\s+{int(prompt_primary_audio_ordinal)}>", re.IGNORECASE)
+        normalized = primary.sub(f"<Audio {int(source_audio_ordinal)}>", normalized)
+
+    warnings: list[str] = []
+    limits = {
+        "picture": int(counts.get("pictures", 0)),
+        "video": int(counts.get("videos", 0)),
+        "audio": int(counts.get("audios", 0)),
+    }
+    for match in OFFICIAL_TAG_RE.finditer(normalized):
+        media_type, ordinal = match.group(1).lower(), int(match.group(2))
+        if ordinal < 1 or ordinal > limits[media_type]:
+            warnings.append(
+                f"{match.group(0)} is not connected; available {media_type} count is {limits[media_type]}"
+            )
+    if strict and warnings:
+        raise ValueError("MiniMax H3 prompt media tag validation failed: " + "; ".join(warnings))
+    return normalized, warnings
+
+
+def media_map_json(
+    pictures: list[str], videos: list[str], audios: list[str], source_audio_ordinal: int = 0
+) -> str:
+    return json.dumps(
+        {
+            "pictures": {str(index + 1): label for index, label in enumerate(pictures)},
+            "videos": {str(index + 1): label for index, label in enumerate(videos)},
+            "audios": {str(index + 1): label for index, label in enumerate(audios)},
+            "source_audio_ordinal": source_audio_ordinal or None,
+        },
+        ensure_ascii=False,
+        indent=2,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "minimax-h3-audio-t8"
+version = "1.0.0"
+description = "Native MiniMax H3 audio conditioning, timing, validation, decode, mix, and trim nodes for ComfyUI"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "GPL-3.0-or-later" }
+dependencies = []
+
+[tool.pytest.ini_options]
+addopts = "--import-mode=importlib"
+testpaths = ["tests"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# No extra packages. torch and torchaudio are supplied by ComfyUI.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+
+
+PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_NAME = "h3_audio_t8_pkg"
+sys.path.insert(0, str(PACKAGE_ROOT / "tests"))
+
+if PACKAGE_NAME not in sys.modules:
+    spec = importlib.util.spec_from_file_location(
+        PACKAGE_NAME,
+        PACKAGE_ROOT / "__init__.py",
+        submodule_search_locations=[str(PACKAGE_ROOT)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[PACKAGE_NAME] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import math
+
+import torch
+
+
+class FakeClip:
+    def __init__(self):
+        self.tokenize_calls = []
+
+    def tokenize(self, prompt, **kwargs):
+        self.tokenize_calls.append((prompt, kwargs))
+        return {"prompt": prompt, "kwargs": kwargs}
+
+    def encode_from_tokens_scheduled(self, tokens):
+        return [[torch.zeros((1, 4, 8)), {"tokens": tokens}]]
+
+
+class FakeVideoVAE:
+    def __init__(self):
+        self.encode_calls = []
+
+    def encode(self, images):
+        self.encode_calls.append(images)
+        frames, height, width = images.shape[:3]
+        latent_t = 1 if frames == 1 else ((frames - 5) // 17) * 5 + 2
+        return torch.zeros((1, 24, latent_t, max(1, height // 16), max(1, width // 16)))
+
+    def decode(self, latent):
+        return torch.zeros((1, latent.shape[2], latent.shape[3] * 16, latent.shape[4] * 16, 3))
+
+
+class FakeAudioVAE:
+    audio_sample_rate = 32000
+    audio_sample_rate_output = 32000
+
+    def __init__(self):
+        self.encode_calls = []
+
+    def encode(self, waveform_last):
+        self.encode_calls.append(waveform_last)
+        latent_t = max(1, math.ceil(waveform_last.shape[1] / 800))
+        return torch.full((1, 32, 2, latent_t), 0.25)
+
+    def decode(self, latent):
+        samples = latent.shape[-1] * 800
+        return torch.full((latent.shape[0], samples, 2), 0.1)
+
+
+def make_audio(seconds=5.0, sample_rate=32000, value=0.1, channels=1):
+    samples = round(seconds * sample_rate)
+    return {"waveform": torch.full((1, channels, samples), value), "sample_rate": sample_rate}

--- a/tests/test_audio_ops.py
+++ b/tests/test_audio_ops.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import torch
+
+from h3_audio_t8_pkg.audio_ops import decode_av_latent, inject_audio_latent, mix_audio, trim_av_output
+from h3_audio_t8_pkg.core import empty_av_latent
+from helpers import FakeAudioVAE, FakeVideoVAE, make_audio
+
+
+def test_standalone_audio_control_lock_and_remix():
+    latent, _ = empty_av_latent(128, 128, 124)
+    vae = FakeAudioVAE()
+    locked, passthrough = inject_audio_latent(latent, make_audio(), vae, "lock", 0.9)
+    assert torch.all(locked["noise_mask"].unbind()[1] == 0)
+    remixed, _ = inject_audio_latent(latent, make_audio(), vae, "remix", 0.4)
+    assert torch.all(remixed["noise_mask"].unbind()[1] == 0.4)
+    assert len(vae.encode_calls) == 2
+
+
+def test_mix_resamples_matches_channels_ducks_and_limits_peak():
+    source = make_audio(1.0, 32000, 0.8, 1)
+    generated = make_audio(0.5, 48000, 0.8, 2)
+    output = mix_audio(source, generated, 0, 0, 0.5, "source", -1.0)
+    assert output["sample_rate"] == 32000
+    assert output["waveform"].shape == (1, 2, 32000)
+    assert float(output["waveform"].abs().max()) <= 10 ** (-1 / 20) + 1e-5
+
+
+def test_decode_returns_both_modalities_and_separate_latents():
+    latent, _ = empty_av_latent(128, 128, 124)
+    images, audio, video_latent, audio_latent = decode_av_latent(latent, FakeVideoVAE(), FakeAudioVAE())
+    assert images.ndim == 4
+    assert audio["sample_rate"] == 32000
+    assert video_latent["samples"].ndim == 5
+    assert audio_latent["samples"].ndim == 4
+
+
+def test_output_trim_applies_same_time_window_to_frames_and_audio():
+    frames = torch.arange(124).view(124, 1, 1, 1).float()
+    audio = make_audio(124 / 24, sample_rate=24000, value=0.2)
+    out_frames, out_audio, report = trim_av_output(frames, 1.0, 2.0, audio, 24.0)
+    assert out_frames.shape[0] == 48
+    assert out_frames[0].item() == 24
+    assert out_audio["waveform"].shape[-1] == 48000

--- a/tests/test_conditioning.py
+++ b/tests/test_conditioning.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import torch
+
+from h3_audio_t8_pkg.conditioning import (
+    HYBRID_KEYFRAME_SENTINEL,
+    assert_hybrid_layout_contract,
+    build_conditioning,
+)
+from helpers import FakeAudioVAE, FakeClip, FakeVideoVAE, make_audio
+
+
+def base_args():
+    return {
+        "clip": FakeClip(),
+        "video_vae": FakeVideoVAE(),
+        "audio_vae": FakeAudioVAE(),
+        "prompt": "Audio 1 drives the performance",
+        "width": 128,
+        "height": 128,
+        "length": 124,
+        "task_type": "auto",
+        "audio_mode": "lock_source",
+        "drive_audio": make_audio(),
+    }
+
+
+def test_source_audio_is_encoded_once_reused_and_locked():
+    args = base_args()
+    conditioning, latent, output_audio, prompt, media_map, report = build_conditioning(**args)
+    assert len(args["audio_vae"].encode_calls) == 1
+    video, audio = latent["samples"].unbind()
+    video_mask, audio_mask = latent["noise_mask"].unbind()
+    assert torch.all(audio[..., :200] == 0.25)
+    assert torch.all(audio[..., 200:] == 0)
+    assert torch.all(video_mask == 1)
+    assert torch.all(audio_mask == 0)
+    assert prompt == "<Audio 1> drives the performance"
+    assert json.loads(media_map)["source_audio_ordinal"] == 1
+    assert output_audio is args["drive_audio"]
+
+
+def test_video_soundtracks_shift_primary_source_audio_tag():
+    args = base_args()
+    args.update({
+        "ref_videos": {"ref_video_1": torch.zeros((48, 64, 64, 3)),
+                       "ref_video_2": torch.zeros((48, 64, 64, 3))},
+        "ref_video_audios": {"ref_video_audio_1": make_audio(2),
+                             "ref_video_audio_2": make_audio(2)},
+        "ref_audios": {"ref_audio_1": make_audio(1)},
+    })
+    conditioning, _, _, prompt, media_map, _ = build_conditioning(**args)
+    media = json.loads(media_map)
+    assert prompt.startswith("<Audio 3>")
+    assert media["source_audio_ordinal"] == 3
+    assert media["audios"] == {
+        "1": "ref_video_audio_1", "2": "ref_video_audio_2",
+        "3": "drive_audio (primary source)", "4": "ref_audio_1",
+    }
+    refs = conditioning[0][1]["minimax_refs"]
+    assert [item["kind"] for item in refs] == ["video_audio", "video_audio", "audio", "audio"]
+
+
+def test_soundtrack_pairing_uses_autogrow_ordinal_not_dense_position():
+    args = base_args()
+    args.update({
+        "ref_videos": {"ref_video_1": torch.zeros((48, 64, 64, 3)),
+                       "ref_video_2": torch.zeros((48, 64, 64, 3))},
+        "ref_video_audios": {"ref_video_audio_2": make_audio(2)},
+    })
+    conditioning, *_ = build_conditioning(**args)
+    refs = conditioning[0][1]["minimax_refs"]
+    assert refs[0]["kind"] == "video"
+    assert refs[1]["kind"] == "video_audio"
+
+
+def test_exact_keyframe_and_audio_reference_use_guarded_hybrid_payload():
+    assert_hybrid_layout_contract()
+    args = base_args()
+    args["first_frame"] = torch.zeros((1, 128, 128, 3))
+    conditioning, _, _, _, media_map, report = build_conditioning(**args)
+    metadata = conditioning[0][1]
+    assert metadata["minimax_keyframes"][0]["resolved_frame_index"] == 0
+    assert metadata["minimax_refs"][0]["kind"] == HYBRID_KEYFRAME_SENTINEL
+    tokenize_kwargs = args["clip"].tokenize_calls[0][1]
+    assert [item["type"] for item in tokenize_kwargs["minimax_ref_items"]] == ["image", "audio"]
+    assert json.loads(media_map)["pictures"]["1"].startswith("first_frame")
+
+
+def test_reference_only_keeps_blank_target_audio():
+    args = base_args()
+    args["audio_mode"] = "reference_only"
+    _, latent, *_ = build_conditioning(**args)
+    _, target_audio = latent["samples"].unbind()
+    assert torch.all(target_audio == 0)
+    assert "noise_mask" not in latent
+
+
+def test_native_t2va_needs_no_source_audio():
+    args = base_args()
+    args.update({"audio_mode": "native", "drive_audio": None, "add_source_as_reference": False,
+                 "prompt": "A person speaks naturally"})
+    conditioning, latent, output_audio, prompt, media_map, report = build_conditioning(**args)
+    assert output_audio is None
+    assert "minimax_refs" not in conditioning[0][1]
+    assert "task=t2va" in report
+
+
+def test_orphan_video_soundtrack_is_rejected():
+    args = base_args()
+    args["ref_video_audios"] = {"ref_video_audio_2": make_audio(2)}
+    with pytest.raises(ValueError, match="no same-numbered video"):
+        build_conditioning(**args)
+
+
+def test_canvas_over_native_area_cap_is_rejected():
+    args = base_args()
+    args.update({"width": 1408, "height": 768})
+    with pytest.raises(ValueError, match="pixel-area cap"):
+        build_conditioning(**args)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import torch
+
+import comfy.nested_tensor
+
+from h3_audio_t8_pkg.core import (
+    align_frame_count,
+    fit_audio_latent,
+    replace_audio_latent,
+    temporal_shape,
+)
+
+
+def test_frame_grid_and_temporal_shapes():
+    assert align_frame_count(5) == 5
+    assert align_frame_count(6) == 22
+    assert align_frame_count(123) == 124
+    assert align_frame_count(124) == 124
+    assert temporal_shape(124) == (124, 37, 207)
+
+
+def test_fit_audio_latent_trims_and_pads():
+    template = torch.zeros((1, 32, 2, 10))
+    short = fit_audio_latent(torch.ones((1, 32, 2, 4)), template)
+    assert short.shape == template.shape
+    assert torch.all(short[..., :4] == 1)
+    assert torch.all(short[..., 4:] == 0)
+    long = fit_audio_latent(torch.ones((1, 32, 2, 20)), template)
+    assert long.shape == template.shape
+    assert torch.all(long == 1)
+
+
+def test_audio_replacement_preserves_existing_video_mask():
+    video = torch.zeros((1, 24, 2, 4, 4))
+    audio = torch.zeros((1, 32, 2, 10))
+    video_mask = torch.full_like(video, 0.42)
+    av = {
+        "samples": comfy.nested_tensor.NestedTensor((video, audio)),
+        "noise_mask": comfy.nested_tensor.NestedTensor((video_mask, torch.ones_like(audio))),
+    }
+    output = replace_audio_latent(av, torch.ones_like(audio), 0.25)
+    out_video_mask, out_audio_mask = output["noise_mask"].unbind()
+    assert torch.equal(out_video_mask, video_mask)
+    assert torch.all(out_audio_mask == 0.25)

--- a/tests/test_preflight_and_registration.py
+++ b/tests/test_preflight_and_registration.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import torch
+
+import h3_audio_t8_pkg
+from h3_audio_t8_pkg.preflight import run_preflight
+from helpers import FakeAudioVAE, FakeVideoVAE, make_audio
+
+
+def test_all_nodes_register_with_unique_ids_and_valid_schemas():
+    extension = h3_audio_t8_pkg.comfy_entrypoint()
+    node_classes = asyncio.run(extension.get_node_list())
+    schemas = [node.define_schema() for node in node_classes]
+    ids = [schema.node_id for schema in schemas]
+    assert len(ids) == 9
+    assert len(ids) == len(set(ids))
+    assert "MiniMaxH3AudioConditioningT8" in ids
+
+
+def test_preflight_reports_alignment_audio_and_reference_guidance():
+    ready, warning_count, report = run_preflight(
+        1344, 768, 123, "lock_source", video_vae=FakeVideoVAE(), audio_vae=FakeAudioVAE(),
+        drive_audio=make_audio(1, value=0),
+        ref_videos={"ref_video_1": torch.zeros((20, 32, 32, 3))},
+    )
+    data = json.loads(report)
+    assert ready is True
+    assert warning_count >= 3
+    assert data["facts"]["aligned_frames"] == 124
+
+
+def test_preflight_blocks_oversize_canvas_and_missing_drive_audio():
+    ready, _, report = run_preflight(1408, 768, 124, "lock_source")
+    assert ready is False
+    assert len(json.loads(report)["errors"]) == 2
+
+
+def test_example_api_workflow_is_valid_and_references_existing_nodes():
+    path = Path(__file__).resolve().parents[1] / "examples" / "audio_lock_api.json"
+    workflow = json.loads(path.read_text(encoding="utf-8"))
+    custom_types = {value["class_type"] for value in workflow.values() if value["class_type"].endswith("T8")}
+    assert custom_types == {
+        "MiniMaxH3AudioWindowT8", "MiniMaxH3AudioConditioningT8",
+        "MiniMaxH3AVDecodeT8", "MiniMaxH3OutputTrimT8",
+    }
+    node_ids = set(workflow)
+    for node in workflow.values():
+        for value in node["inputs"].values():
+            if isinstance(value, list) and len(value) == 2 and isinstance(value[0], str):
+                assert value[0] in node_ids

--- a/tests/test_prompt_tags.py
+++ b/tests/test_prompt_tags.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from h3_audio_t8_pkg.prompt_tags import canonicalize_media_tags, prepare_prompt
+
+
+def test_canonicalizes_all_supported_tag_spellings():
+    prompt = "Image 1 follows <Image 2>; Video #1 reacts to Audio1 and <Audio 2>."
+    assert canonicalize_media_tags(prompt) == (
+        "<Picture 1> follows <Picture 2>; <Video 1> reacts to <Audio 1> and <Audio 2>."
+    )
+
+
+def test_primary_audio_is_remapped_after_video_soundtracks():
+    prompt, warnings = prepare_prompt(
+        "<Audio 1> drives <Picture 1>",
+        {"pictures": 1, "videos": 2, "audios": 3},
+        source_audio_ordinal=3,
+        prompt_primary_audio_ordinal=1,
+        strict=True,
+    )
+    assert prompt == "<Audio 3> drives <Picture 1>"
+    assert warnings == []
+
+
+def test_strict_mode_rejects_disconnected_tags():
+    with pytest.raises(ValueError, match="Audio 2"):
+        prepare_prompt("Use Audio 2", {"pictures": 0, "videos": 0, "audios": 1})
+
+
+def test_non_strict_mode_returns_warnings():
+    prompt, warnings = prepare_prompt(
+        "Video 3", {"pictures": 0, "videos": 1, "audios": 0}, strict=False
+    )
+    assert prompt == "<Video 3>"
+    assert len(warnings) == 1

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+import torch
+
+from h3_audio_t8_pkg.timing import make_timing_plan, window_audio
+from helpers import make_audio
+
+
+def test_short_scene_gets_trained_minimum_context_without_timeline_drift():
+    plan = make_timing_plan(0.0, 1.0, ensure_minimum_context=True, source_duration_seconds=1.0)
+    assert plan.frame_count == 124
+    assert plan.render_duration_seconds == pytest.approx(124 / 24)
+    assert plan.final_duration_seconds == 1.0
+    assert plan.main_prompt_start_seconds == pytest.approx(plan.final_trim_start_seconds)
+    assert "main requested action starts" in plan.prompt_note()
+
+
+def test_warmup_and_alignment_are_reflected_in_final_trim():
+    plan = make_timing_plan(10.0, 2.0, 1.0, 1.0, True, 20.0)
+    assert plan.frame_count == 124
+    assert plan.final_trim_start_seconds == pytest.approx(1 + ((124 / 24) - 4) / 2)
+    assert json.loads(plan.report())["frame_count"] == 124
+
+
+def test_audio_window_slices_and_zero_pads_at_source_start():
+    audio = make_audio(seconds=1.0, sample_rate=24000, value=0.5)
+    plan = make_timing_plan(0.0, 1.0, ensure_minimum_context=True, source_duration_seconds=1.0)
+    output = window_audio(audio, plan)
+    assert output["waveform"].shape[-1] == round((124 / 24) * 24000)
+    first_nonzero = int(torch.nonzero(output["waveform"][0, 0], as_tuple=False)[0])
+    assert first_nonzero == round(plan.left_pad_seconds * 24000)
+
+
+def test_invalid_scene_duration_fails():
+    with pytest.raises(ValueError):
+        make_timing_plan(0, 0)

--- a/timing.py
+++ b/timing.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import json
+import math
+
+from .core import FPS, MIN_TRAINED_FRAMES, align_frame_count, validate_audio
+
+
+@dataclass(frozen=True)
+class TimingPlan:
+    frame_count: int
+    render_duration_seconds: float
+    source_slice_start_seconds: float
+    source_slice_duration_seconds: float
+    left_pad_seconds: float
+    right_pad_seconds: float
+    final_trim_start_seconds: float
+    final_duration_seconds: float
+    main_prompt_start_seconds: float
+    main_prompt_end_seconds: float
+
+    def report(self) -> str:
+        return json.dumps(asdict(self), ensure_ascii=False, indent=2)
+
+    def prompt_note(self) -> str:
+        return (
+            f"Timing: context starts at 0.00s; main requested action starts at "
+            f"{self.main_prompt_start_seconds:.2f}s and ends at {self.main_prompt_end_seconds:.2f}s."
+        )
+
+
+def make_timing_plan(
+    scene_start_seconds: float,
+    scene_duration_seconds: float,
+    warmup_seconds: float = 0.0,
+    cooldown_seconds: float = 0.0,
+    ensure_minimum_context: bool = True,
+    source_duration_seconds: float = 0.0,
+) -> TimingPlan:
+    if scene_start_seconds < 0:
+        raise ValueError("scene_start_seconds cannot be negative")
+    if scene_duration_seconds <= 0:
+        raise ValueError("scene_duration_seconds must be positive")
+    if warmup_seconds < 0 or cooldown_seconds < 0:
+        raise ValueError("warmup_seconds and cooldown_seconds cannot be negative")
+
+    required = warmup_seconds + scene_duration_seconds + cooldown_seconds
+    if ensure_minimum_context:
+        required = max(required, MIN_TRAINED_FRAMES / FPS)
+    extra = max(0.0, required - (warmup_seconds + scene_duration_seconds + cooldown_seconds))
+    ideal_start = scene_start_seconds - warmup_seconds - extra / 2.0
+    ideal_end = scene_start_seconds + scene_duration_seconds + cooldown_seconds + extra / 2.0
+
+    frame_count = align_frame_count(math.ceil((ideal_end - ideal_start) * FPS - 1e-9))
+    render_duration = frame_count / FPS
+    # Grid alignment extends the tail, never shifts the user's requested scene.
+    ideal_end = ideal_start + render_duration
+    slice_start = max(0.0, ideal_start)
+    left_pad = max(0.0, -ideal_start)
+    available_end = source_duration_seconds if source_duration_seconds > 0 else ideal_end
+    slice_end = min(ideal_end, available_end)
+    slice_duration = max(0.0, slice_end - slice_start)
+    right_pad = max(0.0, render_duration - left_pad - slice_duration)
+    trim_start = scene_start_seconds - ideal_start
+
+    return TimingPlan(
+        frame_count=frame_count,
+        render_duration_seconds=render_duration,
+        source_slice_start_seconds=slice_start,
+        source_slice_duration_seconds=slice_duration,
+        left_pad_seconds=left_pad,
+        right_pad_seconds=right_pad,
+        final_trim_start_seconds=trim_start,
+        final_duration_seconds=scene_duration_seconds,
+        main_prompt_start_seconds=trim_start,
+        main_prompt_end_seconds=trim_start + scene_duration_seconds,
+    )
+
+
+def window_audio(audio: dict, plan: TimingPlan) -> dict:
+    waveform, sample_rate = validate_audio(audio)
+    start = round(plan.source_slice_start_seconds * sample_rate)
+    count = round(plan.source_slice_duration_seconds * sample_rate)
+    sliced = waveform[..., start : start + count]
+    left_count = round(plan.left_pad_seconds * sample_rate)
+    target_count = round(plan.render_duration_seconds * sample_rate)
+    output = waveform.new_zeros((waveform.shape[0], waveform.shape[1], target_count))
+    writable = min(sliced.shape[-1], max(0, target_count - left_count))
+    if writable:
+        output[..., left_count : left_count + writable] = sliced[..., :writable]
+    return {"waveform": output, "sample_rate": sample_rate}


### PR DESCRIPTION
## What changed

- Add a standalone ComfyUI MiniMax H3 audio node package with nine registered nodes.
- Support native, reference-only, locked-source, and remix audio modes across T2VA/I2VA/FL2VA/L2VA/Ref2VA/Hybrid conditioning.
- Add official media-tag normalization, dynamic audio ordinals, duration/window planning, preflight validation, AV decode, audio mix, and synchronized output trim.
- Add documentation, structured metadata, an API workflow example, and automated tests.

## Why

The previous implementation mixed reference and target-audio responsibilities, could misnumber audio references when video soundtracks were present, and did not provide a complete timing/validation/output pipeline. This package follows the current native ComfyUI MiniMax H3 contracts and remains independent from the legacy node pack.

## Impact

Users get a self-contained `T8/MiniMax H3/Audio` category with guarded H3 conditioning and end-to-end audio-driven workflow helpers. Existing ComfyUI or legacy custom-node files are not changed.

## Validation

- `ruff check .`
- `pytest -q -p no:cacheprovider` — 27 passed
- ComfyUI `load_custom_node` — 9 nodes registered successfully
