### PR TITLE
Add experimental H3 source AV repaint nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # MiniMax H3 Audio T8
 
-面向当前 ComfyUI 原生 MiniMax H3 的独立 T8 节点扩展。当前版本为 `1.10.0`，共注册
-48 个节点，覆盖原生音画条件、音频控制与后处理、稳定双时钟采样、实验性多速率采样、
+面向当前 ComfyUI 原生 MiniMax H3 的独立 T8 节点扩展。当前版本为 `1.11.0`，共注册
+51 个节点，覆盖原生音画条件、来源视频音画重绘准备、音频控制与后处理、稳定双时钟采样、实验性多速率采样、
 隔离的分段长视频续写、总时长编排、候选/接受状态与文件级合成、Ref2VA 单图/多图
 参考的静态语义编辑，以及带异常释放保护、持久分段、精确时长后期和显式音色库的实验性语音链。
 
-节点按稳定性与用途分为六个菜单：
+节点按稳定性与用途分为七个菜单：
 
 | 菜单 | 状态 | 内容 |
 |---|---|---|
@@ -15,6 +15,7 @@
 | `T8/MiniMax H3/Conditioning/Experimental` | 实验 | 对已有 H3 视觉参考/关键帧 Conditioning 设置全局参考强度，不修改采样链 |
 | `T8/MiniMax H3/Long Video/Experimental` | 实验 | 总时长分段、断点续作、候选预览/接受、后台逐段执行、原子 manifest、已接受上下文与文件级合成 |
 | `T8/MiniMax H3/Speech/Experimental` | 实验 | 描述/参考音色、ASR与身份评估、异常释放保护、逐句对白、长文本断点、ADR和显式音色库 |
+| `T8/MiniMax H3/Source AV/Experimental` | 实验 | 来源视频24fps窗口、H3双流latent严格组装、画面/音频独立mask与无VAE拆分 |
 
 本包不是把源音频简单塞进 latent：它按 ComfyUI 当前 H3 实现维护媒体展示顺序、
 `<Picture N>` / `<Video N>` / `<Audio N>` 标签、联合 AV latent、首尾关键帧、参考媒体和
@@ -29,7 +30,8 @@ MiniMax H3 实现；可选语音校验才延迟导入 `faster-whisper` 或 `tran
 `cbbc9dab1`，运行环境为 Python 3.10+。模型、VAE、CLIP 和可选 LoRA
 仍需按具体任务自行安装。
 
-`1.10.0` 保留此前36个节点的 ID、顺序、默认值和旧接线，只在其后追加12个语音可靠性/
+`1.11.0` 保留此前48个节点的 ID、顺序、默认值和旧接线，只在末尾追加3个完全隔离的 Source AV
+EXP 节点；旧工作流不会自动读取来源视频、改变 latent 或启用重绘 mask。`1.10.0` 保留此前36个节点的 ID、顺序、默认值和旧接线，只在其后追加12个语音可靠性/
 创作 EXP 节点；旧工作流不会自动启用异常全局卸载、持久音色库、长文本或 Joint 多人。
 `1.9.0` 只在原35个节点之后追加一个视觉参考强度 EXP 后置节点；原节点 ID、顺序、默认值和
 旧工作流接线不变，只有用户主动插入节点时才写入实验字段。`1.8.0` 只在原25个节点之后追加10个实验性语音节点；旧节点顺序不变，原工作流不会自动进入
@@ -103,6 +105,9 @@ VideoHelperSuite 的延迟 `AUDIO Mapping`，用 H3 latent 契约识别视频/�
 | MiniMax H3 Speech Long Form Start/Accept/Control/Compose (EXP/T8) | 原子 accepted manifest、断点恢复、合作式取消、分段可播放预览、哈希校验和最终精确时间线合成 |
 | MiniMax H3 Joint Dialogue Conditioning / 多人同段条件 (EXP/T8) | 2–3人 Ref2VA 同段实验；真实两人探针质量门槛失败，不是稳定推荐路径 |
 | MiniMax H3 Visual Reference Strength (EXP/T8) | 在现有 H3 positive Conditioning 后写入全局视觉参考强度；可能缓解过度平滑/蜡感，也可能削弱身份、构图和首尾帧 |
+| MiniMax H3 Source Media Window / 来源视频窗口 (EXP/T8) | 把已有IMAGE/AUDIO按24fps、`17n+5`和32kHz裁为严格同步的短窗口；不是文件流式解码 |
+| MiniMax H3 Source AV Prepare / 来源音画重绘准备 (EXP/T8) | 严格校验并组装视频/音频latent，保留元数据与mask，显式处理时钟差并提供双流lock/remix/regenerate |
+| MiniMax H3 AV Latent Separate / 联合潜空间拆分 (EXP/T8) | 不调用VAE即可校验、拆出H3视频/音频latent并保留各自mask |
 
 `MiniMax H3 Audio Conditioning (T8)` 与 Long Video Conditioning 的 `task_type` 下拉框会显示中英双语说明：
 
@@ -117,6 +122,54 @@ VideoHelperSuite 的延迟 `AUDIO Mapping`，用 H3 latent 契约识别视频/�
 | `Hybrid` | 关键帧与参考媒体混合生成 |
 
 中文仅用于前端显示，后端和 API 仍提交原有英文枚举，因此旧工作流与 API JSON 无需修改。
+
+## EXP：来源视频音画重绘
+
+`1.11.0` 新增的 Source AV 链不是时间轴上的视频拼接器，而是把已有视频与声音规范化、VAE编码
+后作为 H3 的起始联合 AV latent。它支持以下实验组合：
+
+该方向受到 `ptmaster/ComfyUI-PT_H3ConcatAVLatent` 的产品思路启发，但本项目没有复制、打包或
+依赖该仓库代码；实现基于 ComfyUI 原生 GPL AV latent 契约与本项目已有的校验、mask和时间轴
+基础设施独立完成。当前 ComfyUI 已自带通用 `LTXVConcatAVLatent`，本项目新增的是 H3 专用的
+媒体规范化、严格时钟检查、双流模式和风险报告，而不是重复注册一个无校验的通用包装器。
+
+- `video=remix, audio=lock`：重绘画面，尽量保留来源音频 latent；
+- `video=lock, audio=remix/regenerate`：尽量保留画面，重绘或重生声音；
+- 双流 `remix`：画面和声音分别使用自己的 denoise mask；
+- `regenerate`：对应流的 mask 为1，但在真实矩阵通过前不把它描述成完全摆脱来源信息。
+
+推荐连接：
+
+1. Core `Load Video -> Get Video Components`；
+2. frames、audio、fps 进入 `Source Media Window`，选择画布、起点和124帧窗口；
+3. 输出 frames/audio 分别进入标准 `VAE Encode` 与 `VAE Encode Audio`；
+4. 两个 latent 进入 `Source AV Prepare`；
+5. 使用它的 `av_latent` 替换 `SamplerCustomAdvanced.latent_image`，同时接到双时钟节点的
+   `av_latent`；Conditioning 仍只负责 prompt 和媒体条件；
+6. sampler 输出继续使用现有 `AV Decode -> Create Video -> Save Video`。
+
+`Source Media Window` 会把目标帧数向上对齐到 `17n+5`，按来源 fps 选择最接近的帧，并输出
+精确时长的32kHz双声道音频。视频不足默认拒绝；用户显式选择 `hold_last_frame` 才会保持末帧。
+音频不足默认补静音并写入报告；不连接音频时会生成报告标记的静音轨，供 Audio VAE 构造合法
+联合 latent。这个节点接收的完整 IMAGE 已经在内存中，因此不能把它称为长视频流式或低内存解码。
+
+`Source AV Prepare` 严格要求视频 `[1,24,T,H,W]`、音频 `[1,32,2,T40]`、视频
+`T=5n+2`，并校验音频长度是否等于 `round((17n+5)*40/24)`。音频不一致时只能按用户选择的
+`strict`、裁切或补零生成尾部策略处理，不会静默修改。视频元数据优先保留，非冲突音频元数据
+会合并，冲突字段和所有时间调整都会写入 report。
+
+当前没有证据证明 `0.25/0.5/0.75` 会形成视觉上严格单调或线性的重绘权重，也没有完成真实
+H3画质、身份、动作、音频保真和16GB显存矩阵。因此三个节点均为 EXP，不标 `memory_safe`、
+“任意视频”或“精准局部重绘”。API与前端示例分别为：
+
+- `examples/source_video_repaint_api.json`；
+- `examples/workflows/H3_Source_Video_Repaint_Stock20_EXP.json`。
+
+本机已用真实来源有声视频、FL2VA pruned INT8、Qwen3-VL NVFP4 与双 H3 VAE 完成一次
+256×256、124帧、1步机械整链检查；结果成功保存为24fps H.264 + 32kHz stereo AAC，视频与
+音频时长均约5.167秒。该探针只证明加载、双VAE、latent组装、采样、双解码和封装能连通，
+不证明1步画质。运行期间整卡最低空闲仅44.52MiB，远低于512MiB安全门槛，所以16GB环境
+仍属于高风险实验档；在多模式、多强度、三冷三暖及质量矩阵完成前不提供显存安全承诺。
 
 ## EXP：视觉参考强度（Ref2VA 纹理 A/B）
 

--- a/examples/source_video_repaint_api.json
+++ b/examples/source_video_repaint_api.json
@@ -1,0 +1,162 @@
+{
+  "1": {
+    "inputs": {"file": "replace_with_source_video.mp4"},
+    "class_type": "LoadVideo",
+    "_meta": {"title": "Load source video"}
+  },
+  "2": {
+    "inputs": {"video": ["1", 0]},
+    "class_type": "GetVideoComponents",
+    "_meta": {"title": "Extract source frames, audio and FPS"}
+  },
+  "3": {
+    "inputs": {
+      "source_fps": ["2", 2],
+      "width": 736,
+      "height": 416,
+      "length": 124,
+      "start_seconds": 0.0,
+      "short_video_policy": "strict",
+      "short_audio_policy": "pad_silence",
+      "frames": ["2", 0],
+      "source_audio": ["2", 1]
+    },
+    "class_type": "MiniMaxH3SourceMediaWindowT8",
+    "_meta": {"title": "Normalize source to H3 24fps / 17n+5 / 32kHz"}
+  },
+  "4": {
+    "inputs": {"vae_name": "minimax_h3_video_vae_fp16.safetensors"},
+    "class_type": "VAELoader",
+    "_meta": {"title": "Load H3 video VAE"}
+  },
+  "5": {
+    "inputs": {"vae_name": "minimax_h3_audio_vae_fp32.safetensors"},
+    "class_type": "VAELoader",
+    "_meta": {"title": "Load H3 audio VAE"}
+  },
+  "6": {
+    "inputs": {"pixels": ["3", 0], "vae": ["4", 0]},
+    "class_type": "VAEEncode",
+    "_meta": {"title": "Encode source video latent"}
+  },
+  "7": {
+    "inputs": {"audio": ["3", 1], "vae": ["5", 0]},
+    "class_type": "VAEEncodeAudio",
+    "_meta": {"title": "Encode source audio latent"}
+  },
+  "8": {
+    "inputs": {
+      "video_mode": "remix",
+      "video_denoise_strength": 0.5,
+      "audio_mode": "lock",
+      "audio_denoise_strength": 0.35,
+      "audio_fit_policy": "fit_to_video_generate_tail",
+      "dtype_device_policy": "match_video",
+      "video_latent": ["6", 0],
+      "audio_latent": ["7", 0]
+    },
+    "class_type": "MiniMaxH3SourceAVPrepareT8",
+    "_meta": {"title": "Remix source picture and preserve source audio"}
+  },
+  "9": {
+    "inputs": {
+      "unet_name": "minimax_h3_fl2va_int8_convrot.safetensors",
+      "weight_dtype": "default"
+    },
+    "class_type": "UNETLoader",
+    "_meta": {"title": "Load H3 FL2VA model"}
+  },
+  "10": {
+    "inputs": {
+      "clip_name": "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors",
+      "type": "minimax",
+      "device": "default"
+    },
+    "class_type": "CLIPLoader",
+    "_meta": {"title": "Load H3 CLIP"}
+  },
+  "11": {
+    "inputs": {
+      "prompt": "Restyle the source video as a cinematic scene while preserving its action, timing and original sound.",
+      "width": 736,
+      "height": 416,
+      "length": 124,
+      "task_type": "T2VA",
+      "audio_mode": "native",
+      "audio_denoise_strength": 1.0,
+      "add_source_as_reference": false,
+      "prompt_primary_audio_ordinal": 0,
+      "strict_prompt_tags": true,
+      "ref_image_size": "match",
+      "reference_video_policy": "official_2_to_15s",
+      "clip": ["10", 0],
+      "video_vae": ["4", 0],
+      "audio_vae": ["5", 0]
+    },
+    "class_type": "MiniMaxH3AudioConditioningT8",
+    "_meta": {"title": "Build H3 prompt conditioning; use Source AV latent for sampling"}
+  },
+  "12": {
+    "inputs": {
+      "steps": 20,
+      "shift_video": 12.0,
+      "shift_audio": 3.0,
+      "sampler_name": "dual_clock_euler",
+      "scheduler": "native_flow",
+      "model": ["9", 0],
+      "av_latent": ["8", 0]
+    },
+    "class_type": "MiniMaxH3DualClockSamplerT8",
+    "_meta": {"title": "H3 source-video dual-clock setup"}
+  },
+  "13": {
+    "inputs": {"noise_seed": 2608103001},
+    "class_type": "RandomNoise",
+    "_meta": {"title": "Noise"}
+  },
+  "14": {
+    "inputs": {"model": ["12", 0], "conditioning": ["11", 0]},
+    "class_type": "BasicGuider",
+    "_meta": {"title": "Basic guider"}
+  },
+  "15": {
+    "inputs": {
+      "noise": ["13", 0],
+      "guider": ["14", 0],
+      "sampler": ["12", 1],
+      "sigmas": ["12", 2],
+      "latent_image": ["8", 0]
+    },
+    "class_type": "SamplerCustomAdvanced",
+    "_meta": {"title": "Sample source AV repaint"}
+  },
+  "16": {
+    "inputs": {
+      "av_latent": ["15", 0],
+      "video_vae": ["4", 0],
+      "audio_vae": ["5", 0]
+    },
+    "class_type": "MiniMaxH3AVDecodeT8",
+    "_meta": {"title": "Decode repainted video and audio"}
+  },
+  "17": {
+    "inputs": {
+      "images": ["16", 0],
+      "fps": 24.0,
+      "audio": ["16", 1],
+      "bit_depth": 8
+    },
+    "class_type": "CreateVideo",
+    "_meta": {"title": "Create synchronized source repaint"}
+  },
+  "18": {
+    "inputs": {
+      "video": ["17", 0],
+      "filename_prefix": "MiniMaxH3/source_video_repaint",
+      "format": "mp4",
+      "codec": "h264"
+    },
+    "class_type": "SaveVideo",
+    "_meta": {"title": "Save source video repaint"}
+  }
+}

--- a/examples/workflows/H3_Source_Video_Repaint_Stock20_EXP.json
+++ b/examples/workflows/H3_Source_Video_Repaint_Stock20_EXP.json
@@ -1,0 +1,1483 @@
+{
+  "id": "0f7de9ad-2885-4076-ab96-ae3dff308929",
+  "revision": 0,
+  "last_node_id": 18,
+  "last_link_id": 28,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "LoadVideo",
+      "title": "Load source video",
+      "pos": [
+        0,
+        0
+      ],
+      "size": [
+        390,
+        124
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "file",
+          "type": "COMBO",
+          "widget": {
+            "name": "file"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            1
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "LoadVideo"
+      },
+      "widgets_values": [
+        "replace_with_source_video.mp4"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "GetVideoComponents",
+      "title": "Extract source frames, audio and FPS",
+      "pos": [
+        440,
+        0
+      ],
+      "size": [
+        390,
+        110
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 1
+        }
+      ],
+      "outputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "links": [
+            3
+          ]
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": [
+            4
+          ]
+        },
+        {
+          "name": "fps",
+          "type": "FLOAT",
+          "links": [
+            2
+          ]
+        },
+        {
+          "name": "bit_depth",
+          "type": "INT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "GetVideoComponents"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 3,
+      "type": "MiniMaxH3SourceMediaWindowT8",
+      "title": "Normalize source to H3 24fps / 17n+5 / 32kHz",
+      "pos": [
+        880,
+        0
+      ],
+      "size": [
+        390,
+        422
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "source_fps",
+          "type": "FLOAT",
+          "link": 2
+        },
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": null
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": null
+        },
+        {
+          "name": "length",
+          "type": "INT",
+          "widget": {
+            "name": "length"
+          },
+          "link": null
+        },
+        {
+          "name": "start_seconds",
+          "type": "FLOAT",
+          "widget": {
+            "name": "start_seconds"
+          },
+          "link": null
+        },
+        {
+          "name": "short_video_policy",
+          "type": "COMBO",
+          "widget": {
+            "name": "short_video_policy"
+          },
+          "link": null
+        },
+        {
+          "name": "short_audio_policy",
+          "type": "COMBO",
+          "widget": {
+            "name": "short_audio_policy"
+          },
+          "link": null
+        },
+        {
+          "name": "frames",
+          "type": "IMAGE",
+          "link": 3
+        },
+        {
+          "name": "source_audio",
+          "type": "AUDIO",
+          "link": 4
+        }
+      ],
+      "outputs": [
+        {
+          "name": "frames",
+          "type": "IMAGE",
+          "links": [
+            5
+          ]
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": [
+            7
+          ]
+        },
+        {
+          "name": "frame_count",
+          "type": "INT",
+          "links": null
+        },
+        {
+          "name": "duration_seconds",
+          "type": "FLOAT",
+          "links": null
+        },
+        {
+          "name": "report",
+          "type": "STRING",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "minimax-h3-audio-T8",
+        "Node name for S&R": "MiniMaxH3SourceMediaWindowT8"
+      },
+      "widgets_values": [
+        736,
+        416,
+        124,
+        0.0,
+        "strict",
+        "pad_silence"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "VAELoader",
+      "title": "Load H3 video VAE",
+      "pos": [
+        0,
+        300
+      ],
+      "size": [
+        390,
+        124
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "vae_name",
+          "type": "['Wan2.1_VAE.pth', 'Wan2_1_VAE_bf16.safetensors', 'WanVideo_MTV_Crafter_4DMoT_VQVAE_fp32.safetensors', 'ace_1.5_vae.safetensors', 'ae.safetensors', 'cog-vae-mz.safetensors', 'comfy-wan_2.1_vae.safetensors', 'cosmos_cv8x8x8_1.0.safetensors', 'diffusion_pytorch_model.safetensors', 'flux1_vae_bf16.safetensors', 'hunyuan_video_vae_bf16.safetensors', 'hunyuan_video_vae_fp32.safetensors', 'minimax_h3_audio_vae_fp32.safetensors', 'minimax_h3_video_vae_fp16.safetensors', 'mochi\\\\mochi_preview_vae_bf16.safetensors', 'mochi\\\\mochi_preview_vae_decoder_bf16.safetensors', 'mochi_preview_vae_decoder_bf16.safetensors', 'mochi_preview_vae_encoder_bf16_.safetensors', 'mochi_preview_vae_encoder_fp32.safetensors', 'oldt5_xxl_fp8_e4m3fn_scaled.safetensors', 'pyramid_flow_vae_bf16.safetensors', 'pyramid_flow_vae_fp32.safetensors', 'qwen_image_vae.safetensors', 'sdxl_vae_fp16fix.safetensors', 'vae-ft-mse-840000-ema-pruned.safetensors', 'vae-i2v-hunyuan.pt', 'wan2.2_vae.safetensors', 'pixel_space']",
+          "widget": {
+            "name": "vae_name"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            6,
+            12,
+            24
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": [
+        "minimax_h3_video_vae_fp16.safetensors"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "VAELoader",
+      "title": "Load H3 audio VAE",
+      "pos": [
+        0,
+        600
+      ],
+      "size": [
+        390,
+        124
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "vae_name",
+          "type": "['Wan2.1_VAE.pth', 'Wan2_1_VAE_bf16.safetensors', 'WanVideo_MTV_Crafter_4DMoT_VQVAE_fp32.safetensors', 'ace_1.5_vae.safetensors', 'ae.safetensors', 'cog-vae-mz.safetensors', 'comfy-wan_2.1_vae.safetensors', 'cosmos_cv8x8x8_1.0.safetensors', 'diffusion_pytorch_model.safetensors', 'flux1_vae_bf16.safetensors', 'hunyuan_video_vae_bf16.safetensors', 'hunyuan_video_vae_fp32.safetensors', 'minimax_h3_audio_vae_fp32.safetensors', 'minimax_h3_video_vae_fp16.safetensors', 'mochi\\\\mochi_preview_vae_bf16.safetensors', 'mochi\\\\mochi_preview_vae_decoder_bf16.safetensors', 'mochi_preview_vae_decoder_bf16.safetensors', 'mochi_preview_vae_encoder_bf16_.safetensors', 'mochi_preview_vae_encoder_fp32.safetensors', 'oldt5_xxl_fp8_e4m3fn_scaled.safetensors', 'pyramid_flow_vae_bf16.safetensors', 'pyramid_flow_vae_fp32.safetensors', 'qwen_image_vae.safetensors', 'sdxl_vae_fp16fix.safetensors', 'vae-ft-mse-840000-ema-pruned.safetensors', 'vae-i2v-hunyuan.pt', 'wan2.2_vae.safetensors', 'pixel_space']",
+          "widget": {
+            "name": "vae_name"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            8,
+            13,
+            25
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": [
+        "minimax_h3_audio_vae_fp32.safetensors"
+      ]
+    },
+    {
+      "id": 6,
+      "type": "VAEEncode",
+      "title": "Encode source video latent",
+      "pos": [
+        1320,
+        0
+      ],
+      "size": [
+        390,
+        132
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "pixels",
+          "type": "IMAGE",
+          "link": 5
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 6
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            9
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "VAEEncode"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 7,
+      "type": "VAEEncodeAudio",
+      "title": "Encode source audio latent",
+      "pos": [
+        1320,
+        300
+      ],
+      "size": [
+        390,
+        132
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 7
+        },
+        {
+          "name": "vae",
+          "type": "VAE",
+          "link": 8
+        }
+      ],
+      "outputs": [
+        {
+          "name": "LATENT",
+          "type": "LATENT",
+          "links": [
+            10
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "VAEEncodeAudio"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 8,
+      "type": "MiniMaxH3SourceAVPrepareT8",
+      "title": "Remix source picture and preserve source audio",
+      "pos": [
+        1760,
+        0
+      ],
+      "size": [
+        390,
+        396
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video_mode",
+          "type": "COMBO",
+          "widget": {
+            "name": "video_mode"
+          },
+          "link": null
+        },
+        {
+          "name": "video_denoise_strength",
+          "type": "FLOAT",
+          "widget": {
+            "name": "video_denoise_strength"
+          },
+          "link": null
+        },
+        {
+          "name": "audio_mode",
+          "type": "COMBO",
+          "widget": {
+            "name": "audio_mode"
+          },
+          "link": null
+        },
+        {
+          "name": "audio_denoise_strength",
+          "type": "FLOAT",
+          "widget": {
+            "name": "audio_denoise_strength"
+          },
+          "link": null
+        },
+        {
+          "name": "audio_fit_policy",
+          "type": "COMBO",
+          "widget": {
+            "name": "audio_fit_policy"
+          },
+          "link": null
+        },
+        {
+          "name": "dtype_device_policy",
+          "type": "COMBO",
+          "widget": {
+            "name": "dtype_device_policy"
+          },
+          "link": null
+        },
+        {
+          "name": "video_latent",
+          "type": "LATENT",
+          "link": 9
+        },
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "link": 10
+        }
+      ],
+      "outputs": [
+        {
+          "name": "av_latent",
+          "type": "LATENT",
+          "links": [
+            15,
+            22
+          ]
+        },
+        {
+          "name": "video_latent",
+          "type": "LATENT",
+          "links": null
+        },
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "links": null
+        },
+        {
+          "name": "report",
+          "type": "STRING",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "minimax-h3-audio-T8",
+        "Node name for S&R": "MiniMaxH3SourceAVPrepareT8"
+      },
+      "widgets_values": [
+        "remix",
+        0.5,
+        "lock",
+        0.35,
+        "fit_to_video_generate_tail",
+        "match_video"
+      ]
+    },
+    {
+      "id": 9,
+      "type": "UNETLoader",
+      "title": "Load H3 FL2VA model",
+      "pos": [
+        0,
+        900
+      ],
+      "size": [
+        390,
+        168
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "unet_name",
+          "type": "['CogVideoX_5b_fun_GGUF_Q4_0.safetensors', 'Comfy-hunyuan_video_image_to_video_720p_bf16.safetensors', 'ComfyUI_00001_.safetensors', 'FramePackI2V_HY_converted_experimental_fp8_e4m3fn.safetensors', 'FramePackI2V_HY_fp8_e4m3fn.safetensors', 'Framer_controlnet_fp16.safetensors', 'Framer_unet_fp16.safetensors', 'LongCat_TI2V_comfy_bf16.safetensors', 'MelBandRoformer_fp32.safetensors', 'Phantom-Wan-14B_fp8_e4m3fn.safetensors', 'Phantom-Wan-1_3B_fp16.safetensors', 'VACE1.3b.safetensors', 'Wan2.1-T2V-1.3B-Self-Forcing-DMD-VACE-FP16.safetensors', 'Wan2_1-Wan-I2V-ATI-14B_fp8_e4m3fn.safetensors', 'acestep_v1.5_turbo.safetensors', 'acestep_v1.5_xl_sft_bf16.safetensors', 'acestep_v1.5_xl_turbo_bf16.safetensors', 'aniWan2114BFp8E4m3fn_i2v480pNew.safetensors', 'anima-base-v1.0.safetensors', 'boogu_image_base_fp8_scaled.safetensors', 'boogu_image_edit_fp8_scaled.safetensors', 'boogu_image_turbo_fp8_scaled.safetensors', 'comfy-hunyuan_video_v2_replace_image_to_video_720p_bf16.safetensors', 'comfy-wan2.1_i2v_480p_14B_bf16 .safetensors', 'comfy-wan2.1_i2v_720p_14B_bf16.safetensors', 'comfy-wan2.1_t2v_1.3B_bf16.safetensors', 'comfy-wan2.1_t2v_14B_bf16.safetensors', 'hunyuan_video_720_cfgdistill_fp8_e4m3fn.safetensors', 'hunyuan_video_FastVideo_720_fp8_e4m3fn.safetensors', 'hunyuan_video_I2V_720_fixed_fp8_e4m3fn.safetensors', 'hunyuan_video_I2V_fp8_e4m3fn.safetensors', 'hunyuan_video_accvid-t2v-5-steps_fp8_e4m3fn.safetensors', 'hunyuan_video_custom_720p_fp8_scaled.safetensors', 'minimax_h3_fl2va_int8_convrot.safetensors', 'minimax_h3_fl2va_pruned_int8_convrot.safetensors', 'minimax_h3_ref2va_attn_last8_g102.safetensors', 'minimax_h3_ref2va_attn_last8_g105.safetensors', 'minimax_h3_ref2va_int8_convrot.safetensors', 'minimax_h3_ref2va_pruned_int8_convrot.safetensors', 'minimax_h3_ref2va_videohead_hf101.safetensors', 'minimax_h3_ref2va_videohead_hf102.safetensors', 'minimax_h3_ref2va_videohead_hf104.safetensors', 'mochi\\\\mochi_preview_dit_GGUF_Q4_0_v2.safetensors', 'mochi\\\\mochi_preview_dit_fp8_e4m3fn.safetensors', 'mp_rank_00_model_states.pt', 'mp_rank_00_model_states_fp8.pt', 'mp_rank_00_model_states_fp8_map.pt', 'n-wan_1.3B_e10.safetensors', 'nsfw_wan_14b_e1.safetensors', 'self_forcing_dmd.pt', 'skyreels_hunyuan_i2v_fp8_e4m3fn.safetensors', 'skyreels_hunyuan_t2v_fp8_e4m3fn.safetensors', 'svdq-fp4_r128-z-image-turbo.safetensors', 'svdq-int4_r128-z-image-turbo.safetensors', 'svdq-int4_r256-z-image-turbo.safetensors', 'wan_1.3B_e20.safetensors', 'wan_1.3B_exp_e14.safetensors', 'z-image-turbo-fp8-e4m3fn.safetensors', 'z_image_bf16.safetensors', 'z_image_turbo_bf16.safetensors']",
+          "widget": {
+            "name": "unet_name"
+          },
+          "link": null
+        },
+        {
+          "name": "weight_dtype",
+          "type": "['default', 'fp8_e4m3fn', 'fp8_e4m3fn_fast', 'fp8_e5m2']",
+          "widget": {
+            "name": "weight_dtype"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            14
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "minimax_h3_fl2va_int8_convrot.safetensors",
+        "default"
+      ]
+    },
+    {
+      "id": 10,
+      "type": "CLIPLoader",
+      "title": "Load H3 CLIP",
+      "pos": [
+        0,
+        1200
+      ],
+      "size": [
+        390,
+        212
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip_name",
+          "type": "['Long-ViT-L-14-GmP-SAE-TE-only.safetensors', 'ViT-L-14-GmP-SAE-TE-only.safetensors', 'clip-vit-large-patch14\\\\model.safetensors', 'clip_l.safetensors', 'gemma_3_12B_it.safetensors', 'google-flan-t5-large\\\\model.safetensors', 'llava_llama3_fp8_scaled.safetensors', 'models_t5_umt5-xxl-enc-bf16.pth', 'nsfw_wan_umt5-xxl_fp8_scaled.safetensors', 'oldt5_xxl_fp8_e4m3fn_scaled.safetensors', 'open-clip-xlm-roberta-large-vit-huge-14_fp16.safetensors', 'open-clip-xlm-roberta-large-vit-huge-14_visual_fp32.safetensors', 'qwen3.5_2b_bf16.safetensors', 'qwen3vl_32b_minimax_h3_int8_convrot.safetensors', 'qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors', 'qwen3vl_8b_fp8_scaled.safetensors', 'qwen_0.6b_ace15.safetensors', 'qwen_1.7b_ace15.safetensors', 'qwen_3_06b_base.safetensors', 'qwen_3_4b.safetensors', 't5\\\\google_t5-v1_1-xxl_encoderonly-fp8_e4m3fn.safetensors', 't5gemma_b_b_ul2.safetensors', 't5xxl_fp16.safetensors', 't5xxl_fp8_e4m3fn.safetensors', 'umt5-xxl-enc-bf16.safetensors', 'umt5_xxl_fp16.safetensors', 'umt5_xxl_fp8_e4m3fn_scaled.safetensors']",
+          "widget": {
+            "name": "clip_name"
+          },
+          "link": null
+        },
+        {
+          "name": "type",
+          "type": "['stable_diffusion', 'stable_cascade', 'sd3', 'stable_audio', 'mochi', 'ltxv', 'pixart', 'cosmos', 'lumina2', 'wan', 'hidream', 'chroma', 'ace', 'omnigen2', 'qwen_image', 'hunyuan_image', 'flux2', 'ovis', 'longcat_image', 'cogvideox', 'lens', 'pixeldit', 'ideogram4', 'boogu', 'krea2', 'joyimage', 'mage', 'minimax']",
+          "widget": {
+            "name": "type"
+          },
+          "link": null
+        },
+        {
+          "name": "device",
+          "type": "['default', 'cpu']",
+          "widget": {
+            "name": "device"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            11
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors",
+        "minimax",
+        "default"
+      ]
+    },
+    {
+      "id": 11,
+      "type": "MiniMaxH3AudioConditioningT8",
+      "title": "Build H3 prompt conditioning; use Source AV latent for sampling",
+      "pos": [
+        440,
+        300
+      ],
+      "size": [
+        390,
+        686
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "prompt",
+          "type": "STRING",
+          "widget": {
+            "name": "prompt"
+          },
+          "link": null
+        },
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": null
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": null
+        },
+        {
+          "name": "length",
+          "type": "INT",
+          "widget": {
+            "name": "length"
+          },
+          "link": null
+        },
+        {
+          "name": "task_type",
+          "type": "COMBO",
+          "widget": {
+            "name": "task_type"
+          },
+          "link": null
+        },
+        {
+          "name": "audio_mode",
+          "type": "COMBO",
+          "widget": {
+            "name": "audio_mode"
+          },
+          "link": null
+        },
+        {
+          "name": "audio_denoise_strength",
+          "type": "FLOAT",
+          "widget": {
+            "name": "audio_denoise_strength"
+          },
+          "link": null
+        },
+        {
+          "name": "add_source_as_reference",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "add_source_as_reference"
+          },
+          "link": null
+        },
+        {
+          "name": "prompt_primary_audio_ordinal",
+          "type": "INT",
+          "widget": {
+            "name": "prompt_primary_audio_ordinal"
+          },
+          "link": null
+        },
+        {
+          "name": "strict_prompt_tags",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "strict_prompt_tags"
+          },
+          "link": null
+        },
+        {
+          "name": "ref_image_size",
+          "type": "COMBO",
+          "widget": {
+            "name": "ref_image_size"
+          },
+          "link": null
+        },
+        {
+          "name": "reference_video_policy",
+          "type": "COMBO",
+          "widget": {
+            "name": "reference_video_policy"
+          },
+          "link": null
+        },
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 11
+        },
+        {
+          "name": "video_vae",
+          "type": "VAE",
+          "link": 12
+        },
+        {
+          "name": "audio_vae",
+          "type": "VAE",
+          "link": 13
+        }
+      ],
+      "outputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "links": [
+            17
+          ]
+        },
+        {
+          "name": "av_latent",
+          "type": "LATENT",
+          "links": null
+        },
+        {
+          "name": "mux_audio",
+          "type": "AUDIO",
+          "links": null
+        },
+        {
+          "name": "conditioned_prompt",
+          "type": "STRING",
+          "links": null
+        },
+        {
+          "name": "media_map_json",
+          "type": "STRING",
+          "links": null
+        },
+        {
+          "name": "report",
+          "type": "STRING",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "minimax-h3-audio-T8",
+        "Node name for S&R": "MiniMaxH3AudioConditioningT8"
+      },
+      "widgets_values": [
+        "Restyle the source video as a cinematic scene while preserving its action, timing and original sound.",
+        736,
+        416,
+        124,
+        "T2VA",
+        "native",
+        1.0,
+        false,
+        0,
+        true,
+        "match",
+        "official_2_to_15s"
+      ]
+    },
+    {
+      "id": 12,
+      "type": "MiniMaxH3DualClockSamplerT8",
+      "title": "H3 source-video dual-clock setup",
+      "pos": [
+        2200,
+        0
+      ],
+      "size": [
+        390,
+        352
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "steps",
+          "type": "INT",
+          "widget": {
+            "name": "steps"
+          },
+          "link": null
+        },
+        {
+          "name": "shift_video",
+          "type": "FLOAT",
+          "widget": {
+            "name": "shift_video"
+          },
+          "link": null
+        },
+        {
+          "name": "shift_audio",
+          "type": "FLOAT",
+          "widget": {
+            "name": "shift_audio"
+          },
+          "link": null
+        },
+        {
+          "name": "sampler_name",
+          "type": "COMBO",
+          "widget": {
+            "name": "sampler_name"
+          },
+          "link": null
+        },
+        {
+          "name": "scheduler",
+          "type": "COMBO",
+          "widget": {
+            "name": "scheduler"
+          },
+          "link": null
+        },
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 14
+        },
+        {
+          "name": "av_latent",
+          "type": "LATENT",
+          "link": 15
+        }
+      ],
+      "outputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "links": [
+            16
+          ]
+        },
+        {
+          "name": "sampler",
+          "type": "SAMPLER",
+          "links": [
+            20
+          ]
+        },
+        {
+          "name": "sigmas",
+          "type": "SIGMAS",
+          "links": [
+            21
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "minimax-h3-audio-T8",
+        "Node name for S&R": "MiniMaxH3DualClockSamplerT8"
+      },
+      "widgets_values": [
+        20,
+        12.0,
+        3.0,
+        "dual_clock_euler",
+        "native_flow"
+      ]
+    },
+    {
+      "id": 13,
+      "type": "RandomNoise",
+      "title": "Noise",
+      "pos": [
+        0,
+        1500
+      ],
+      "size": [
+        390,
+        142
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "noise_seed",
+          "type": "INT",
+          "widget": {
+            "name": "noise_seed"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "NOISE",
+          "type": "NOISE",
+          "links": [
+            18
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "RandomNoise"
+      },
+      "widgets_values": [
+        2608103001,
+        "fixed"
+      ]
+    },
+    {
+      "id": 14,
+      "type": "BasicGuider",
+      "title": "Basic guider",
+      "pos": [
+        2640,
+        0
+      ],
+      "size": [
+        390,
+        132
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 16
+        },
+        {
+          "name": "conditioning",
+          "type": "CONDITIONING",
+          "link": 17
+        }
+      ],
+      "outputs": [
+        {
+          "name": "GUIDER",
+          "type": "GUIDER",
+          "links": [
+            19
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "BasicGuider"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 15,
+      "type": "SamplerCustomAdvanced",
+      "title": "Sample source AV repaint",
+      "pos": [
+        3080,
+        0
+      ],
+      "size": [
+        390,
+        210
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "noise",
+          "type": "NOISE",
+          "link": 18
+        },
+        {
+          "name": "guider",
+          "type": "GUIDER",
+          "link": 19
+        },
+        {
+          "name": "sampler",
+          "type": "SAMPLER",
+          "link": 20
+        },
+        {
+          "name": "sigmas",
+          "type": "SIGMAS",
+          "link": 21
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 22
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "type": "LATENT",
+          "links": [
+            23
+          ]
+        },
+        {
+          "name": "denoised_output",
+          "type": "LATENT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "SamplerCustomAdvanced"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 16,
+      "type": "MiniMaxH3AVDecodeT8",
+      "title": "Decode repainted video and audio",
+      "pos": [
+        3520,
+        0
+      ],
+      "size": [
+        390,
+        158
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "av_latent",
+          "type": "LATENT",
+          "link": 23
+        },
+        {
+          "name": "video_vae",
+          "type": "VAE",
+          "link": 24
+        },
+        {
+          "name": "audio_vae",
+          "type": "VAE",
+          "link": 25
+        }
+      ],
+      "outputs": [
+        {
+          "name": "frames",
+          "type": "IMAGE",
+          "links": [
+            26
+          ]
+        },
+        {
+          "name": "generated_audio",
+          "type": "AUDIO",
+          "links": [
+            27
+          ]
+        },
+        {
+          "name": "video_latent",
+          "type": "LATENT",
+          "links": null
+        },
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "minimax-h3-audio-T8",
+        "Node name for S&R": "MiniMaxH3AVDecodeT8"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 17,
+      "type": "CreateVideo",
+      "title": "Create synchronized source repaint",
+      "pos": [
+        3960,
+        0
+      ],
+      "size": [
+        390,
+        220
+      ],
+      "flags": {},
+      "order": 16,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 26
+        },
+        {
+          "name": "fps",
+          "type": "FLOAT",
+          "widget": {
+            "name": "fps"
+          },
+          "link": null
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 27
+        },
+        {
+          "name": "bit_depth",
+          "type": "INT",
+          "widget": {
+            "name": "bit_depth"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VIDEO",
+          "type": "VIDEO",
+          "links": [
+            28
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "CreateVideo"
+      },
+      "widgets_values": [
+        24.0,
+        8
+      ]
+    },
+    {
+      "id": 18,
+      "type": "SaveVideo",
+      "title": "Save source video repaint",
+      "pos": [
+        4400,
+        0
+      ],
+      "size": [
+        390,
+        238
+      ],
+      "flags": {},
+      "order": 17,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "link": 28
+        },
+        {
+          "name": "filename_prefix",
+          "type": "STRING",
+          "widget": {
+            "name": "filename_prefix"
+          },
+          "link": null
+        },
+        {
+          "name": "format",
+          "type": "COMBO",
+          "widget": {
+            "name": "format"
+          },
+          "link": null
+        },
+        {
+          "name": "codec",
+          "type": "COMFY_DYNAMICCOMBO_V3",
+          "widget": {
+            "name": "codec"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "video",
+          "type": "VIDEO",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "SaveVideo"
+      },
+      "widgets_values": [
+        "MiniMaxH3/source_video_repaint",
+        "mp4",
+        "h264"
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      1,
+      0,
+      2,
+      0,
+      "VIDEO"
+    ],
+    [
+      2,
+      2,
+      2,
+      3,
+      0,
+      "FLOAT"
+    ],
+    [
+      3,
+      2,
+      0,
+      3,
+      7,
+      "IMAGE"
+    ],
+    [
+      4,
+      2,
+      1,
+      3,
+      8,
+      "AUDIO"
+    ],
+    [
+      5,
+      3,
+      0,
+      6,
+      0,
+      "IMAGE"
+    ],
+    [
+      6,
+      4,
+      0,
+      6,
+      1,
+      "VAE"
+    ],
+    [
+      7,
+      3,
+      1,
+      7,
+      0,
+      "AUDIO"
+    ],
+    [
+      8,
+      5,
+      0,
+      7,
+      1,
+      "VAE"
+    ],
+    [
+      9,
+      6,
+      0,
+      8,
+      6,
+      "LATENT"
+    ],
+    [
+      10,
+      7,
+      0,
+      8,
+      7,
+      "LATENT"
+    ],
+    [
+      11,
+      10,
+      0,
+      11,
+      12,
+      "CLIP"
+    ],
+    [
+      12,
+      4,
+      0,
+      11,
+      13,
+      "VAE"
+    ],
+    [
+      13,
+      5,
+      0,
+      11,
+      14,
+      "VAE"
+    ],
+    [
+      14,
+      9,
+      0,
+      12,
+      5,
+      "MODEL"
+    ],
+    [
+      15,
+      8,
+      0,
+      12,
+      6,
+      "LATENT"
+    ],
+    [
+      16,
+      12,
+      0,
+      14,
+      0,
+      "MODEL"
+    ],
+    [
+      17,
+      11,
+      0,
+      14,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      18,
+      13,
+      0,
+      15,
+      0,
+      "NOISE"
+    ],
+    [
+      19,
+      14,
+      0,
+      15,
+      1,
+      "GUIDER"
+    ],
+    [
+      20,
+      12,
+      1,
+      15,
+      2,
+      "SAMPLER"
+    ],
+    [
+      21,
+      12,
+      2,
+      15,
+      3,
+      "SIGMAS"
+    ],
+    [
+      22,
+      8,
+      0,
+      15,
+      4,
+      "LATENT"
+    ],
+    [
+      23,
+      15,
+      0,
+      16,
+      0,
+      "LATENT"
+    ],
+    [
+      24,
+      4,
+      0,
+      16,
+      1,
+      "VAE"
+    ],
+    [
+      25,
+      5,
+      0,
+      16,
+      2,
+      "VAE"
+    ],
+    [
+      26,
+      16,
+      0,
+      17,
+      0,
+      "IMAGE"
+    ],
+    [
+      27,
+      16,
+      1,
+      17,
+      2,
+      "AUDIO"
+    ],
+    [
+      28,
+      17,
+      0,
+      18,
+      0,
+      "VIDEO"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.75,
+      "offset": [
+        120,
+        120
+      ]
+    },
+    "workflow_title": "MiniMax H3 Source Video Repaint Stock20 EXP"
+  },
+  "version": 0.4
+}

--- a/features.json
+++ b/features.json
@@ -64,7 +64,10 @@
     "MiniMaxH3SpeechLongFormAcceptT8",
     "MiniMaxH3SpeechLongFormControlT8",
     "MiniMaxH3SpeechLongFormComposeT8",
-    "MiniMaxH3JointDialogueConditioningT8"
+    "MiniMaxH3JointDialogueConditioningT8",
+    "MiniMaxH3SourceMediaWindowT8",
+    "MiniMaxH3SourceAVPrepareT8",
+    "MiniMaxH3AVLatentSeparateT8"
   ],
   "sampling": {
     "algorithm": "selectable sampler and scheduler with a backward-compatible dual-clock default",
@@ -530,6 +533,66 @@
       "a 16GiB memory_safe or never-OOM tier"
     ],
     "status": "guarded failure cleanup, durable long-form accepted state, exact-sample ADR, explicit voice persistence, validation harnesses and creator workflows implemented; quality-sensitive capabilities remain Experimental or denied as stated"
+  },
+  "experimental_source_av": {
+    "category": "T8/MiniMax H3/Source AV/Experimental",
+    "nodes": [
+      "MiniMaxH3SourceMediaWindowT8",
+      "MiniMaxH3SourceAVPrepareT8",
+      "MiniMaxH3AVLatentSeparateT8"
+    ],
+    "positioning": "H3-specific source-video repaint and AV stream routing; independent implementation inspired by the product direction, not copied from or dependent on ComfyUI-PT_H3ConcatAVLatent",
+    "media_window_contract": {
+      "target_fps": 24,
+      "frame_grid": "17n+5",
+      "audio_sample_rate": 32000,
+      "short_video_policies": ["strict", "hold_last_frame"],
+      "short_audio_policies": ["strict", "pad_silence"],
+      "scope": "IMAGE input is already resident; not streaming decode and not a low-memory long-video implementation"
+    },
+    "latent_contract": {
+      "video": "[B,24,T,H/16,W/16], B=1, T=5n+2",
+      "audio": "[B,32,2,T40], B=1",
+      "clock": "audio T must equal round((17n+5)*40/24) after an explicit fit policy",
+      "stream_modes": ["lock", "remix", "regenerate"],
+      "audio_fit_policies": [
+        "strict",
+        "trim_to_video",
+        "pad_to_video_generate_tail",
+        "fit_to_video_generate_tail"
+      ],
+      "metadata": "video metadata is authoritative; non-conflicting audio metadata is merged; conflicting keys are reported",
+      "mask": "input masks are preserved as constraints and multiplied by the explicit stream mode strength; padded audio tail receives mask 1"
+    },
+    "compatibility": "all prior 48 node IDs, ordering and defaults are unchanged; the three Source AV EXP nodes are appended",
+    "api_example": "examples/source_video_repaint_api.json",
+    "frontend_workflow": "examples/workflows/H3_Source_Video_Repaint_Stock20_EXP.json",
+    "validated": [
+      "CPU tensor contract, temporal inverse, dtype normalization, explicit audio trim/pad and input immutability",
+      "noise-mask and metadata preservation",
+      "isolated ComfyUI registration and API-to-frontend workflow conversion",
+      "one real-model mechanical full chain: voiced source media through both H3 VAEs, source AV prepare, one-step FL2VA INT8 sampling, both decoders and 24fps H.264 plus 32kHz stereo AAC output"
+    ],
+    "validated_real_probe": {
+      "date": "2026-08-10",
+      "environment": "RTX 4060 Ti 16GiB; Windows; ComfyUI 0.31.0 at cbbc9dab1; DynamicVRAM",
+      "models": "FL2VA pruned INT8, Qwen3-VL NVFP4, H3 video VAE FP16 and audio VAE FP32",
+      "source": "voiced 2560x1440 24fps input windowed to 256x256, 124 frames",
+      "sampler": "one-step mechanical acceptance probe; not a perceptual-quality test",
+      "output": "124 frames at 24fps, H.264, 5.166667s video; 32kHz stereo AAC, 5.167s audio",
+      "minimum_observed_headroom_mib": 44.52,
+      "decision": "mechanical chain passed; 16GiB memory_safe is denied because headroom is below the 512MiB gate",
+      "local_evidence": "artifacts/source-av-real-forward/source_video_repaint_1step_00001_.mp4"
+    },
+    "unvalidated_or_denied": [
+      "denoise strength as a calibrated or linear redraw weight",
+      "real H3 source-video perceptual quality, identity preservation and prompt adherence",
+      "16GiB memory_safe or never-OOM claim",
+      "arbitrary non-24fps or non-17n+5 latent windows",
+      "file-backed streaming source decode and long-video repaint integration",
+      "precise spatial inpainting"
+    ],
+    "status": "mechanical EXP implementation and one real-model one-step end-to-end path passed; denoise, perceptual quality and full VRAM matrix remain required, and the observed 44.52MiB minimum headroom denies a 16GiB memory_safe tier"
   },
   "experimental_visual_reference_strength": {
     "node": "MiniMaxH3VisualReferenceStrengthEXPT8",

--- a/meta.json
+++ b/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "minimax-h3-audio-T8",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "category": "T8/MiniMax H3/Audio",
   "license": "GPL-3.0-or-later",
   "validated_on": "2026-08-10",

--- a/nodes.py
+++ b/nodes.py
@@ -27,6 +27,7 @@ from .nodes_still_exp import (
     MiniMaxH3StillPreflightT8,
 )
 from .nodes_speech_exp import SPEECH_NODE_CLASSES
+from .nodes_source_av_exp import SOURCE_AV_NODE_CLASSES
 from .nodes_visual_reference_exp import MiniMaxH3VisualReferenceStrengthEXPT8
 from .preflight import run_preflight
 from .prompt_tags import prepare_prompt
@@ -383,7 +384,8 @@ class MiniMaxH3AudioT8Extension(ComfyExtension):
                 MiniMaxH3LongVideoAutoQueueT8,
                 *SPEECH_NODE_CLASSES[:10],
                 MiniMaxH3VisualReferenceStrengthEXPT8,
-                *SPEECH_NODE_CLASSES[10:]]
+                *SPEECH_NODE_CLASSES[10:],
+                *SOURCE_AV_NODE_CLASSES]
 
 
 def comfy_entrypoint():

--- a/nodes_source_av_exp.py
+++ b/nodes_source_av_exp.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from comfy_api.latest import io
+
+from .source_av import (
+    AUDIO_FIT_POLICIES,
+    DTYPE_DEVICE_POLICIES,
+    SHORT_AUDIO_POLICIES,
+    SHORT_VIDEO_POLICIES,
+    STREAM_MODES,
+    prepare_source_media_window,
+    prepare_source_av_latent,
+    separate_source_av_latent,
+)
+
+
+CATEGORY = "T8/MiniMax H3/Source AV/Experimental"
+
+
+class MiniMaxH3SourceMediaWindowT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3SourceMediaWindowT8",
+            display_name="MiniMax H3 Source Media Window / 来源视频窗口 (EXP/T8)",
+            description=(
+                "Selects a 24fps, 17n+5 source window, resizes it to an H3 canvas, and creates "
+                "an exactly timed 32kHz stereo audio window for the standard video/audio VAE "
+                "encoders. The full IMAGE input is already resident; this is not streaming decode "
+                "and does not claim a memory-safe long-video path."
+            ),
+            category=CATEGORY,
+            is_experimental=True,
+            inputs=[
+                io.Image.Input("frames"),
+                io.Float.Input("source_fps", default=24.0, min=0.01, max=240.0, step=0.001),
+                io.Int.Input("width", default=736, min=32, max=1920, step=32),
+                io.Int.Input("height", default=416, min=32, max=1088, step=32),
+                io.Int.Input(
+                    "length",
+                    default=124,
+                    min=5,
+                    max=362,
+                    step=17,
+                    tooltip="Snapped up to H3's 17n+5 target grid.",
+                ),
+                io.Float.Input(
+                    "start_seconds",
+                    default=0.0,
+                    min=0.0,
+                    max=86400.0,
+                    step=0.001,
+                ),
+                io.Combo.Input(
+                    "short_video_policy",
+                    options=list(SHORT_VIDEO_POLICIES),
+                    default="strict",
+                    display_name="short video / 视频不足",
+                ),
+                io.Combo.Input(
+                    "short_audio_policy",
+                    options=list(SHORT_AUDIO_POLICIES),
+                    default="pad_silence",
+                    display_name="short audio / 音频不足",
+                ),
+                io.Audio.Input(
+                    "source_audio",
+                    optional=True,
+                    tooltip="Optional source soundtrack. Missing audio becomes reported stereo silence.",
+                ),
+            ],
+            outputs=[
+                io.Image.Output("frames"),
+                io.Audio.Output("audio"),
+                io.Int.Output("frame_count"),
+                io.Float.Output("duration_seconds"),
+                io.String.Output("report"),
+            ],
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        frames,
+        source_fps,
+        width,
+        height,
+        length,
+        start_seconds,
+        short_video_policy,
+        short_audio_policy,
+        source_audio=None,
+    ):
+        return io.NodeOutput(
+            *prepare_source_media_window(
+                frames,
+                source_fps,
+                width,
+                height,
+                length,
+                start_seconds,
+                short_video_policy,
+                short_audio_policy,
+                source_audio,
+            )
+        )
+
+
+class MiniMaxH3SourceAVPrepareT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3SourceAVPrepareT8",
+            display_name="MiniMax H3 Source AV Prepare / 来源音画重绘准备 (EXP/T8)",
+            description=(
+                "Strictly assembles H3 video/audio latents, preserves metadata and masks, "
+                "aligns the audio clock only under an explicit policy, and creates separate "
+                "video/audio denoise masks. This is stream assembly, not temporal concat; "
+                "denoise strength is experimental and is not claimed to be a linear redraw weight."
+            ),
+            category=CATEGORY,
+            is_experimental=True,
+            inputs=[
+                io.Latent.Input(
+                    "video_latent",
+                    tooltip="H3 video latent [B,24,T,H,W], or an existing H3 joint AV latent.",
+                ),
+                io.Latent.Input(
+                    "audio_latent",
+                    tooltip="H3 audio latent [B,32,2,T], or an H3 joint AV latent whose audio stream will be used.",
+                ),
+                io.Combo.Input(
+                    "video_mode",
+                    options=list(STREAM_MODES),
+                    default="remix",
+                    display_name="video mode / 画面模式",
+                    tooltip="lock=mask 0; remix=use strength; regenerate=mask 1.",
+                ),
+                io.Float.Input(
+                    "video_denoise_strength",
+                    default=0.5,
+                    min=0.0,
+                    max=1.0,
+                    step=0.01,
+                    display_name="video denoise / 画面重绘强度",
+                    tooltip="Used only by remix. No linear visual-strength claim is made before real A/B calibration.",
+                ),
+                io.Combo.Input(
+                    "audio_mode",
+                    options=list(STREAM_MODES),
+                    default="lock",
+                    display_name="audio mode / 音频模式",
+                    tooltip="lock=preserve source latent; remix=use strength; regenerate=mask 1.",
+                ),
+                io.Float.Input(
+                    "audio_denoise_strength",
+                    default=0.35,
+                    min=0.0,
+                    max=1.0,
+                    step=0.01,
+                    display_name="audio denoise / 音频重绘强度",
+                    tooltip="Used only by remix; regenerated or padded audio still requires perceptual validation.",
+                ),
+                io.Combo.Input(
+                    "audio_fit_policy",
+                    options=list(AUDIO_FIT_POLICIES),
+                    default="fit_to_video_generate_tail",
+                    display_name="audio fit / 音频时钟对齐",
+                    tooltip=(
+                        "strict never adjusts. trim/pad policies are explicit; a padded tail is zero latent "
+                        "with mask 1 so H3 may generate it. Every adjustment is reported."
+                    ),
+                ),
+                io.Combo.Input(
+                    "dtype_device_policy",
+                    options=list(DTYPE_DEVICE_POLICIES),
+                    default="match_video",
+                    display_name="dtype/device / 精度与设备",
+                    advanced=True,
+                    tooltip="match_video converts only the smaller audio stream; strict refuses a mismatch.",
+                ),
+            ],
+            outputs=[
+                io.Latent.Output("av_latent"),
+                io.Latent.Output("video_latent"),
+                io.Latent.Output("audio_latent"),
+                io.String.Output("report"),
+            ],
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        video_latent,
+        audio_latent,
+        video_mode,
+        video_denoise_strength,
+        audio_mode,
+        audio_denoise_strength,
+        audio_fit_policy,
+        dtype_device_policy,
+    ):
+        return io.NodeOutput(
+            *prepare_source_av_latent(
+                video_latent,
+                audio_latent,
+                video_mode,
+                video_denoise_strength,
+                audio_mode,
+                audio_denoise_strength,
+                audio_fit_policy,
+                dtype_device_policy,
+            )
+        )
+
+
+class MiniMaxH3AVLatentSeparateT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3AVLatentSeparateT8",
+            display_name="MiniMax H3 AV Latent Separate / 联合潜空间拆分 (EXP/T8)",
+            description=(
+                "Validates and separates a joint H3 AV latent without invoking either VAE. "
+                "It preserves metadata and per-stream noise masks, so it is cheaper than decoding "
+                "when only latent routing or replacement is needed."
+            ),
+            category=CATEGORY,
+            is_experimental=True,
+            inputs=[io.Latent.Input("av_latent")],
+            outputs=[
+                io.Latent.Output("video_latent"),
+                io.Latent.Output("audio_latent"),
+                io.String.Output("report"),
+            ],
+        )
+
+    @classmethod
+    def execute(cls, av_latent):
+        return io.NodeOutput(*separate_source_av_latent(av_latent))
+
+
+SOURCE_AV_NODE_CLASSES = [
+    MiniMaxH3SourceMediaWindowT8,
+    MiniMaxH3SourceAVPrepareT8,
+    MiniMaxH3AVLatentSeparateT8,
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "minimax-h3-audio-t8"
-version = "1.10.0"
-description = "MiniMax H3 audio, guarded experimental speech/long-form voice workflows, visual-reference strength, dual-clock sampling, resumable long-video orchestration, and Ref2VA still-image editing nodes for ComfyUI"
+version = "1.11.0"
+description = "MiniMax H3 audio, source-video AV repaint preparation, guarded speech/long-form voice workflows, dual-clock sampling, resumable long-video orchestration, and Ref2VA editing nodes for ComfyUI"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "GPL-3.0-or-later" }

--- a/source_av.py
+++ b/source_av.py
@@ -1,0 +1,540 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+
+import torch
+import torchaudio
+
+import comfy.nested_tensor
+import comfy.utils
+
+from .core import (
+    AUDIO_LATENT_FPS,
+    FPS,
+    MAX_PIXELS,
+    MAX_TRAINED_FRAMES,
+    MIN_TRAINED_FRAMES,
+    align_frame_count,
+    resize_image,
+    validate_audio,
+)
+
+
+VIDEO_CHANNELS = 24
+AUDIO_CHANNELS = 32
+AUDIO_STEREO = 2
+SOURCE_AV_SCHEMA = "h3_t8_source_av_v1"
+STREAM_MODES = ("lock", "remix", "regenerate")
+AUDIO_FIT_POLICIES = (
+    "strict",
+    "trim_to_video",
+    "pad_to_video_generate_tail",
+    "fit_to_video_generate_tail",
+)
+DTYPE_DEVICE_POLICIES = ("match_video", "strict")
+SOURCE_AUDIO_SAMPLE_RATE = 32000
+SHORT_VIDEO_POLICIES = ("strict", "hold_last_frame")
+SHORT_AUDIO_POLICIES = ("strict", "pad_silence")
+
+
+def frame_count_from_video_latent_t(latent_t: int) -> int:
+    latent_t = int(latent_t)
+    if latent_t < 2 or (latent_t - 2) % 5:
+        raise ValueError(
+            "MiniMax H3 video latent T must satisfy T = 5n+2; "
+            f"got T={latent_t}. Pre-trim the source to a 17n+5 frame window before VAE encode."
+        )
+    return ((latent_t - 2) // 5) * 17 + 5
+
+
+def prepare_source_media_window(
+    frames: torch.Tensor,
+    source_fps: float,
+    width: int,
+    height: int,
+    length: int,
+    start_seconds: float,
+    short_video_policy: str,
+    short_audio_policy: str,
+    source_audio: Mapping | None = None,
+):
+    if not isinstance(frames, torch.Tensor) or frames.ndim != 4:
+        shape = tuple(frames.shape) if isinstance(frames, torch.Tensor) else type(frames).__name__
+        raise ValueError(f"frames must be IMAGE [N,H,W,C], got {shape}")
+    if frames.shape[0] < 1 or frames.shape[-1] < 3:
+        raise ValueError("source video frames are empty or do not contain RGB channels")
+    if float(source_fps) <= 0:
+        raise ValueError("source_fps must be positive")
+    if start_seconds < 0:
+        raise ValueError("start_seconds must be nonnegative")
+    if width <= 0 or height <= 0 or width % 32 or height % 32:
+        raise ValueError("H3 source output width and height must be positive multiples of 32")
+    if width * height > MAX_PIXELS:
+        raise ValueError(
+            f"H3 source output {width}x{height} exceeds the configured {MAX_PIXELS:,}-pixel limit"
+        )
+    if short_video_policy not in SHORT_VIDEO_POLICIES:
+        raise ValueError(f"Unknown short video policy {short_video_policy!r}")
+    if short_audio_policy not in SHORT_AUDIO_POLICIES:
+        raise ValueError(f"Unknown short audio policy {short_audio_policy!r}")
+
+    frame_count = align_frame_count(length)
+    target_times = start_seconds + torch.arange(frame_count, dtype=torch.float64) / FPS
+    source_indices = torch.round(target_times * float(source_fps)).to(torch.long)
+    beyond = source_indices >= frames.shape[0]
+    held_video_frames = int(beyond.sum().item())
+    if held_video_frames and short_video_policy == "strict":
+        required_end = start_seconds + (frame_count - 1) / FPS
+        available_end = (frames.shape[0] - 1) / float(source_fps)
+        raise ValueError(
+            "Source video is too short for the requested H3 window: "
+            f"needs frame time {required_end:.6f}s, available through {available_end:.6f}s"
+        )
+    source_indices = source_indices.clamp(0, frames.shape[0] - 1).to(frames.device)
+    selected = frames.index_select(0, source_indices)
+    selected = resize_image(selected, width, height, "disabled")
+
+    duration_seconds = frame_count / FPS
+    target_audio_samples = round(duration_seconds * SOURCE_AUDIO_SAMPLE_RATE)
+    audio_source = "connected_audio"
+    padded_audio_samples = 0
+    if source_audio is None:
+        waveform = torch.zeros((1, 2, target_audio_samples), dtype=torch.float32)
+        audio_source = "generated_silence"
+        audio_input_rate = None
+        audio_input_channels = None
+    else:
+        waveform, audio_input_rate = validate_audio(source_audio, "source_audio")
+        audio_input_channels = waveform.shape[1]
+        if waveform.shape[1] == 1:
+            waveform = waveform.expand(-1, 2, -1)
+        elif waveform.shape[1] != 2:
+            waveform = waveform.mean(dim=1, keepdim=True).expand(-1, 2, -1)
+        if audio_input_rate != SOURCE_AUDIO_SAMPLE_RATE:
+            waveform = torchaudio.functional.resample(
+                waveform,
+                audio_input_rate,
+                SOURCE_AUDIO_SAMPLE_RATE,
+            )
+        start_sample = round(start_seconds * SOURCE_AUDIO_SAMPLE_RATE)
+        available = waveform[..., start_sample : start_sample + target_audio_samples]
+        if available.shape[-1] < target_audio_samples:
+            if short_audio_policy == "strict":
+                raise ValueError(
+                    "Source audio is too short for the requested H3 window: "
+                    f"needs {target_audio_samples} samples from {start_sample}, "
+                    f"got {available.shape[-1]}"
+                )
+            padded_audio_samples = target_audio_samples - available.shape[-1]
+            padding = available.new_zeros((*available.shape[:-1], padded_audio_samples))
+            available = torch.cat((available, padding), dim=-1)
+        waveform = available
+
+    output_audio = {
+        "waveform": waveform,
+        "sample_rate": SOURCE_AUDIO_SAMPLE_RATE,
+    }
+    warnings = []
+    if held_video_frames:
+        warnings.append(f"Held the last source frame for {held_video_frames} target frames.")
+    if padded_audio_samples:
+        warnings.append(f"Padded {padded_audio_samples} source-audio samples with silence.")
+    if audio_source == "generated_silence":
+        warnings.append("No source audio was connected; generated a silent stereo track for VAE encode.")
+    if not MIN_TRAINED_FRAMES <= frame_count <= MAX_TRAINED_FRAMES:
+        warnings.append(
+            f"{frame_count} target frames are outside the approximate H3 trained range "
+            f"{MIN_TRAINED_FRAMES}-{MAX_TRAINED_FRAMES}."
+        )
+
+    report = {
+        "schema": SOURCE_AV_SCHEMA,
+        "status": "source_media_window_ready",
+        "facts": {
+            "input_frame_count": frames.shape[0],
+            "input_resolution": [frames.shape[2], frames.shape[1]],
+            "source_fps": float(source_fps),
+            "start_seconds": float(start_seconds),
+            "target_fps": FPS,
+            "requested_length": int(length),
+            "aligned_frame_count": frame_count,
+            "target_resolution": [width, height],
+            "duration_seconds": duration_seconds,
+            "first_source_frame_index": int(source_indices[0].item()),
+            "last_source_frame_index": int(source_indices[-1].item()),
+            "held_video_frames": held_video_frames,
+            "audio_source": audio_source,
+            "input_audio_sample_rate": audio_input_rate,
+            "input_audio_channels": audio_input_channels,
+            "target_audio_sample_rate": SOURCE_AUDIO_SAMPLE_RATE,
+            "target_audio_samples": target_audio_samples,
+            "padded_audio_samples": padded_audio_samples,
+        },
+        "warnings": warnings,
+        "claims": {
+            "streaming_decode": False,
+            "memory_safe": False,
+            "arbitrary_video_supported": False,
+        },
+    }
+    return (
+        selected,
+        output_audio,
+        frame_count,
+        duration_seconds,
+        json.dumps(report, ensure_ascii=False, indent=2),
+    )
+
+
+def _require_latent(value: Mapping, name: str) -> tuple[Mapping, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a connected LATENT value")
+    if "samples" not in value:
+        raise ValueError(f"{name} is missing samples")
+    return value, value["samples"]
+
+
+def _nested_parts(samples, name: str) -> tuple[torch.Tensor, torch.Tensor]:
+    if not getattr(samples, "is_nested", False):
+        raise ValueError(f"{name} is not a joint AV latent")
+    parts = tuple(samples.unbind())
+    if len(parts) != 2:
+        raise ValueError(f"{name} must contain exactly video and audio streams; got {len(parts)}")
+    if not all(isinstance(part, torch.Tensor) for part in parts):
+        raise ValueError(f"{name} contains a non-tensor stream")
+    return parts
+
+
+def _extract_masks(latent: Mapping, samples, name: str):
+    masks = latent.get("noise_mask")
+    if masks is None:
+        return (None, None) if getattr(samples, "is_nested", False) else None
+    if getattr(samples, "is_nested", False):
+        if not getattr(masks, "is_nested", False):
+            if isinstance(masks, torch.Tensor):
+                return masks, None
+            raise ValueError(f"{name} has an unsupported AV noise_mask")
+        parts = tuple(masks.unbind())
+        if len(parts) != 2:
+            raise ValueError(f"{name} AV noise_mask must contain two streams")
+        return parts
+    if getattr(masks, "is_nested", False) or not isinstance(masks, torch.Tensor):
+        raise ValueError(f"{name} has a noise_mask incompatible with its samples")
+    return masks
+
+
+def _extract_video_source(video_latent: Mapping):
+    latent, samples = _require_latent(video_latent, "video_latent")
+    if getattr(samples, "is_nested", False):
+        video, fallback_audio = _nested_parts(samples, "video_latent")
+        video_mask, fallback_audio_mask = _extract_masks(latent, samples, "video_latent")
+        return video, video_mask, fallback_audio, fallback_audio_mask, True
+    if not isinstance(samples, torch.Tensor):
+        raise ValueError("video_latent samples must be a torch.Tensor or joint AV NestedTensor")
+    return samples, _extract_masks(latent, samples, "video_latent"), None, None, False
+
+
+def _extract_audio_source(audio_latent: Mapping | None, fallback_audio, fallback_mask):
+    if audio_latent is None:
+        if fallback_audio is None:
+            raise ValueError("audio_latent is required when video_latent is not already a joint AV latent")
+        return fallback_audio, fallback_mask, "existing_av_stream", None
+
+    latent, samples = _require_latent(audio_latent, "audio_latent")
+    if getattr(samples, "is_nested", False):
+        _video, audio = _nested_parts(samples, "audio_latent")
+        _video_mask, audio_mask = _extract_masks(latent, samples, "audio_latent")
+        return audio, audio_mask, "audio_input_av_stream", latent
+    if not isinstance(samples, torch.Tensor):
+        raise ValueError("audio_latent samples must be a torch.Tensor or joint AV NestedTensor")
+    return samples, _extract_masks(latent, samples, "audio_latent"), "audio_input", latent
+
+
+def _validate_video(video: torch.Tensor) -> tuple[int, int, int]:
+    if video.ndim != 5:
+        raise ValueError(f"H3 video latent must be [B,24,T,H,W], got {tuple(video.shape)}")
+    if video.shape[0] != 1:
+        raise ValueError(f"MiniMax H3 currently supports video batch size 1; got {video.shape[0]}")
+    if video.shape[1] != VIDEO_CHANNELS:
+        raise ValueError(f"H3 video latent must have 24 channels; got {video.shape[1]}")
+    if not video.is_floating_point():
+        raise ValueError(f"H3 video latent must use a floating dtype; got {video.dtype}")
+    if min(video.shape[2:]) <= 0:
+        raise ValueError(f"H3 video latent cannot contain an empty dimension: {tuple(video.shape)}")
+    if video.shape[-2] % 2 or video.shape[-1] % 2:
+        raise ValueError(
+            "H3 source canvas must be divisible by 32; encoded latent H/W must both be even, "
+            f"got {tuple(video.shape[-2:])}"
+        )
+    frames = frame_count_from_video_latent_t(video.shape[2])
+    height = video.shape[-2] * 16
+    width = video.shape[-1] * 16
+    if width * height > MAX_PIXELS:
+        raise ValueError(
+            f"H3 source canvas {width}x{height} exceeds the configured {MAX_PIXELS:,}-pixel limit"
+        )
+    return frames, width, height
+
+
+def _validate_audio(audio: torch.Tensor, video_batch: int) -> None:
+    if audio.ndim != 4:
+        raise ValueError(f"H3 audio latent must be [B,32,2,T], got {tuple(audio.shape)}")
+    if audio.shape[0] != video_batch:
+        raise ValueError(
+            f"H3 video/audio latent batches must match; video={video_batch}, audio={audio.shape[0]}"
+        )
+    if audio.shape[1] != AUDIO_CHANNELS or audio.shape[2] != AUDIO_STEREO:
+        raise ValueError(
+            "H3 audio latent must use 32 channels and stereo dimension 2; "
+            f"got {tuple(audio.shape)}"
+        )
+    if audio.shape[-1] <= 0:
+        raise ValueError("H3 audio latent cannot be empty")
+    if not audio.is_floating_point():
+        raise ValueError(f"H3 audio latent must use a floating dtype; got {audio.dtype}")
+
+
+def _mode_scale(mode: str, strength: float) -> float:
+    if mode not in STREAM_MODES:
+        raise ValueError(f"Unknown source AV stream mode {mode!r}")
+    if not 0.0 <= float(strength) <= 1.0:
+        raise ValueError("Source AV denoise strength must be between 0 and 1")
+    if mode == "lock":
+        return 0.0
+    if mode == "regenerate":
+        return 1.0
+    return float(strength)
+
+
+def _effective_mask(mask, samples: torch.Tensor, scale: float) -> torch.Tensor:
+    if mask is None:
+        return torch.full_like(samples, scale)
+    if not isinstance(mask, torch.Tensor):
+        raise ValueError("Source AV noise masks must be torch.Tensor values")
+    mask = mask.to(device=samples.device, dtype=samples.dtype)
+    if tuple(mask.shape) != tuple(samples.shape):
+        mask = comfy.utils.reshape_mask(mask, samples.shape)
+    return mask.clamp(0.0, 1.0) * scale
+
+
+def _fit_audio_to_video(
+    audio: torch.Tensor,
+    audio_mask: torch.Tensor,
+    target_t: int,
+    policy: str,
+) -> tuple[torch.Tensor, torch.Tensor, str]:
+    if policy not in AUDIO_FIT_POLICIES:
+        raise ValueError(f"Unknown audio fit policy {policy!r}")
+    current_t = audio.shape[-1]
+    if current_t == target_t:
+        return audio, audio_mask, "exact"
+    if current_t > target_t:
+        if policy not in {"trim_to_video", "fit_to_video_generate_tail"}:
+            raise ValueError(
+                f"Audio latent is longer than the H3 video clock ({current_t}>{target_t}); "
+                "choose trim_to_video or fit_to_video_generate_tail explicitly"
+            )
+        return (
+            audio[..., :target_t],
+            audio_mask[..., :target_t],
+            f"trimmed_{current_t - target_t}_latent_steps",
+        )
+
+    if policy not in {"pad_to_video_generate_tail", "fit_to_video_generate_tail"}:
+        raise ValueError(
+            f"Audio latent is shorter than the H3 video clock ({current_t}<{target_t}); "
+            "choose pad_to_video_generate_tail or fit_to_video_generate_tail explicitly"
+        )
+    pad_t = target_t - current_t
+    pad_shape = (*audio.shape[:-1], pad_t)
+    padded_audio = torch.cat((audio, audio.new_zeros(pad_shape)), dim=-1)
+    padded_mask = torch.cat((audio_mask, audio_mask.new_ones(pad_shape)), dim=-1)
+    return padded_audio, padded_mask, f"padded_{pad_t}_latent_steps_generate_tail"
+
+
+def _merge_metadata(video_latent: Mapping, audio_latent: Mapping | None):
+    output = {
+        key: value
+        for key, value in video_latent.items()
+        if key not in {"samples", "noise_mask"}
+    }
+    merged = []
+    conflicts = []
+    if audio_latent is not None:
+        for key, value in audio_latent.items():
+            if key in {"samples", "noise_mask"}:
+                continue
+            if key in output:
+                conflicts.append(key)
+                continue
+            output[key] = value
+            merged.append(key)
+    return output, merged, conflicts
+
+
+def prepare_source_av_latent(
+    video_latent: Mapping,
+    audio_latent: Mapping | None,
+    video_mode: str,
+    video_denoise_strength: float,
+    audio_mode: str,
+    audio_denoise_strength: float,
+    audio_fit_policy: str,
+    dtype_device_policy: str,
+):
+    if dtype_device_policy not in DTYPE_DEVICE_POLICIES:
+        raise ValueError(f"Unknown dtype/device policy {dtype_device_policy!r}")
+
+    video, video_mask, fallback_audio, fallback_audio_mask, input_was_av = _extract_video_source(
+        video_latent
+    )
+    audio, audio_mask, audio_source, audio_mapping = _extract_audio_source(
+        audio_latent, fallback_audio, fallback_audio_mask
+    )
+    frames, width, height = _validate_video(video)
+    _validate_audio(audio, video.shape[0])
+
+    original_audio_device = str(audio.device)
+    original_audio_dtype = str(audio.dtype)
+    converted_audio = False
+    if audio.device != video.device or audio.dtype != video.dtype:
+        if dtype_device_policy == "strict":
+            raise ValueError(
+                "H3 video/audio dtype and device must match in strict mode: "
+                f"video={video.device}/{video.dtype}, audio={audio.device}/{audio.dtype}"
+            )
+        audio = audio.to(device=video.device, dtype=video.dtype)
+        if audio_mask is not None:
+            audio_mask = audio_mask.to(device=video.device, dtype=video.dtype)
+        converted_audio = True
+
+    video_scale = _mode_scale(video_mode, video_denoise_strength)
+    audio_scale = _mode_scale(audio_mode, audio_denoise_strength)
+    effective_video_mask = _effective_mask(video_mask, video, video_scale)
+    effective_audio_mask = _effective_mask(audio_mask, audio, audio_scale)
+
+    expected_audio_t = round(frames * AUDIO_LATENT_FPS / FPS)
+    input_audio_t = audio.shape[-1]
+    audio, effective_audio_mask, fit_action = _fit_audio_to_video(
+        audio,
+        effective_audio_mask,
+        expected_audio_t,
+        audio_fit_policy,
+    )
+
+    output, merged_metadata, metadata_conflicts = _merge_metadata(video_latent, audio_mapping)
+    output["samples"] = comfy.nested_tensor.NestedTensor((video, audio))
+    output["noise_mask"] = comfy.nested_tensor.NestedTensor(
+        (effective_video_mask, effective_audio_mask)
+    )
+
+    video_output = {
+        key: value for key, value in output.items() if key not in {"samples", "noise_mask"}
+    }
+    audio_output = video_output.copy()
+    video_output["samples"] = video
+    audio_output["samples"] = audio
+    video_output["noise_mask"] = effective_video_mask
+    audio_output["noise_mask"] = effective_audio_mask
+
+    warnings = []
+    if not MIN_TRAINED_FRAMES <= frames <= MAX_TRAINED_FRAMES:
+        warnings.append(
+            f"{frames} source frames are outside the approximate H3 trained range "
+            f"{MIN_TRAINED_FRAMES}-{MAX_TRAINED_FRAMES}."
+        )
+    if converted_audio:
+        warnings.append(
+            "Audio latent dtype/device was matched to the video latent; this may allocate a new audio tensor."
+        )
+    if fit_action != "exact":
+        warnings.append(f"Audio timeline was explicitly adjusted: {fit_action}.")
+    if metadata_conflicts:
+        warnings.append(
+            "Conflicting audio metadata keys were not allowed to overwrite video metadata: "
+            + ", ".join(metadata_conflicts)
+        )
+
+    report = {
+        "schema": SOURCE_AV_SCHEMA,
+        "status": "experimental_ready",
+        "facts": {
+            "input_video_was_av": input_was_av,
+            "audio_source": audio_source,
+            "video_shape": list(video.shape),
+            "input_audio_shape": [audio.shape[0], audio.shape[1], audio.shape[2], input_audio_t],
+            "output_audio_shape": list(audio.shape),
+            "canvas": [width, height],
+            "frame_count": frames,
+            "duration_seconds": frames / FPS,
+            "video_latent_fps": f"17n+5 frames at {FPS}fps",
+            "audio_latent_fps": AUDIO_LATENT_FPS,
+            "expected_audio_t": expected_audio_t,
+            "audio_fit_policy": audio_fit_policy,
+            "audio_fit_action": fit_action,
+            "video_mode": video_mode,
+            "video_effective_denoise": video_scale,
+            "audio_mode": audio_mode,
+            "audio_effective_denoise": audio_scale,
+            "video_device": str(video.device),
+            "video_dtype": str(video.dtype),
+            "input_audio_device": original_audio_device,
+            "input_audio_dtype": original_audio_dtype,
+            "audio_converted_to_video": converted_audio,
+            "merged_audio_metadata_keys": merged_metadata,
+            "metadata_conflicts_kept_from_video": metadata_conflicts,
+        },
+        "warnings": warnings,
+        "claims": {
+            "denoise_strength_is_calibrated_linear_weight": False,
+            "memory_safe": False,
+            "arbitrary_video_supported": False,
+            "temporal_concat": False,
+        },
+    }
+    return output, video_output, audio_output, json.dumps(report, ensure_ascii=False, indent=2)
+
+
+def separate_source_av_latent(av_latent: Mapping):
+    latent, samples = _require_latent(av_latent, "av_latent")
+    video, audio = _nested_parts(samples, "av_latent")
+    frames, width, height = _validate_video(video)
+    _validate_audio(audio, video.shape[0])
+    expected_audio_t = round(frames * AUDIO_LATENT_FPS / FPS)
+    if audio.shape[-1] != expected_audio_t:
+        raise ValueError(
+            "H3 AV latent audio clock does not match its video stream: "
+            f"audio T={audio.shape[-1]}, expected {expected_audio_t} for {frames} frames"
+        )
+
+    masks = _extract_masks(latent, samples, "av_latent")
+    video_mask, audio_mask = masks
+    metadata = {
+        key: value for key, value in latent.items() if key not in {"samples", "noise_mask"}
+    }
+    video_output = metadata.copy()
+    audio_output = metadata.copy()
+    video_output["samples"] = video
+    audio_output["samples"] = audio
+    if video_mask is not None:
+        video_output["noise_mask"] = video_mask
+    if audio_mask is not None:
+        audio_output["noise_mask"] = audio_mask
+
+    report = {
+        "schema": SOURCE_AV_SCHEMA,
+        "status": "valid_h3_av_latent",
+        "facts": {
+            "video_shape": list(video.shape),
+            "audio_shape": list(audio.shape),
+            "canvas": [width, height],
+            "frame_count": frames,
+            "duration_seconds": frames / FPS,
+            "audio_t": audio.shape[-1],
+            "has_video_noise_mask": video_mask is not None,
+            "has_audio_noise_mask": audio_mask is not None,
+            "metadata_keys": sorted(metadata),
+        },
+    }
+    return video_output, audio_output, json.dumps(report, ensure_ascii=False, indent=2)

--- a/tests/test_preflight_and_registration.py
+++ b/tests/test_preflight_and_registration.py
@@ -16,7 +16,7 @@ def test_all_nodes_register_with_unique_ids_and_valid_schemas():
     node_classes = asyncio.run(extension.get_node_list())
     schemas = [node.define_schema() for node in node_classes]
     ids = [schema.node_id for schema in schemas]
-    assert len(ids) == 48
+    assert len(ids) == 51
     assert len(ids) == len(set(ids))
     features = json.loads(
         (Path(__file__).resolve().parents[1] / "features.json").read_text(
@@ -117,7 +117,7 @@ def test_all_nodes_register_with_unique_ids_and_valid_schemas():
         "MiniMaxH3SpeechStudioT8",
     ]
     assert ids[35] == "MiniMaxH3VisualReferenceStrengthEXPT8"
-    assert ids[36:] == [
+    assert ids[36:48] == [
         "MiniMaxH3SpeechGuardT8",
         "MiniMaxH3SpeechVRAMPreflightT8",
         "MiniMaxH3VoiceLibrarySaveT8",
@@ -131,6 +131,11 @@ def test_all_nodes_register_with_unique_ids_and_valid_schemas():
         "MiniMaxH3SpeechLongFormComposeT8",
         "MiniMaxH3JointDialogueConditioningT8",
     ]
+    assert ids[48:] == [
+        "MiniMaxH3SourceMediaWindowT8",
+        "MiniMaxH3SourceAVPrepareT8",
+        "MiniMaxH3AVLatentSeparateT8",
+    ]
     assert ids[23:25] == [
         "MiniMaxH3LongVideoBackgroundStartT8",
         "MiniMaxH3LongVideoAutoQueueT8",
@@ -143,6 +148,26 @@ def test_all_nodes_register_with_unique_ids_and_valid_schemas():
     visual_strength = schemas[ids.index("MiniMaxH3VisualReferenceStrengthEXPT8")]
     assert visual_strength.is_experimental is True
     assert visual_strength.category == "T8/MiniMax H3/Conditioning/Experimental"
+
+    for source_av_id in ids[48:]:
+        source_av_schema = schemas[ids.index(source_av_id)]
+        assert source_av_schema.is_experimental is True
+        assert source_av_schema.category == "T8/MiniMax H3/Source AV/Experimental"
+
+    source_media = schemas[ids.index("MiniMaxH3SourceMediaWindowT8")]
+    media_inputs = {item.id: item for item in source_media.inputs}
+    assert media_inputs["length"].default == 124
+    assert media_inputs["short_video_policy"].default == "strict"
+    assert media_inputs["short_audio_policy"].default == "pad_silence"
+    assert media_inputs["source_audio"].optional is True
+
+    source_prepare = schemas[ids.index("MiniMaxH3SourceAVPrepareT8")]
+    source_inputs = {item.id: item for item in source_prepare.inputs}
+    assert source_inputs["video_mode"].default == "remix"
+    assert source_inputs["video_denoise_strength"].default == 0.5
+    assert source_inputs["audio_mode"].default == "lock"
+    assert source_inputs["audio_fit_policy"].default == "fit_to_video_generate_tail"
+    assert source_inputs["dtype_device_policy"].default == "match_video"
 
     voice_profile = schemas[ids.index("MiniMaxH3VoiceProfileT8")]
     rights = next(item for item in voice_profile.inputs if item.id == "rights_confirmed")

--- a/tests/test_source_av.py
+++ b/tests/test_source_av.py
@@ -1,0 +1,364 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+import comfy.nested_tensor
+
+from h3_audio_t8_pkg.source_av import (
+    frame_count_from_video_latent_t,
+    prepare_source_media_window,
+    prepare_source_av_latent,
+    separate_source_av_latent,
+)
+
+
+def make_video(value=1.0, latent_t=37, dtype=torch.float32):
+    return torch.full((1, 24, latent_t, 4, 6), value, dtype=dtype)
+
+
+def make_audio(value=2.0, latent_t=207, dtype=torch.float32):
+    return torch.full((1, 32, 2, latent_t), value, dtype=dtype)
+
+
+def prepare(video_latent, audio_latent, **overrides):
+    values = {
+        "video_mode": "remix",
+        "video_denoise_strength": 0.5,
+        "audio_mode": "lock",
+        "audio_denoise_strength": 0.35,
+        "audio_fit_policy": "strict",
+        "dtype_device_policy": "match_video",
+    }
+    values.update(overrides)
+    return prepare_source_av_latent(video_latent, audio_latent, **values)
+
+
+def test_video_latent_clock_inverse_is_strict():
+    assert frame_count_from_video_latent_t(2) == 5
+    assert frame_count_from_video_latent_t(7) == 22
+    assert frame_count_from_video_latent_t(37) == 124
+    with pytest.raises(ValueError, match=r"5n\+2"):
+        frame_count_from_video_latent_t(36)
+
+
+def test_source_media_window_resamples_frames_and_makes_reported_silence():
+    frames = (
+        torch.arange(12, dtype=torch.float32).div(11).reshape(12, 1, 1, 1).expand(-1, 8, 8, 3)
+    )
+    selected, audio, frame_count, duration, report = prepare_source_media_window(
+        frames,
+        source_fps=48.0,
+        width=64,
+        height=64,
+        length=5,
+        start_seconds=0.0,
+        short_video_policy="strict",
+        short_audio_policy="pad_silence",
+        source_audio=None,
+    )
+    data = json.loads(report)
+
+    assert selected.shape == (5, 64, 64, 3)
+    assert torch.allclose(
+        selected[:, 0, 0, 0],
+        torch.tensor([0.0, 2 / 11, 4 / 11, 6 / 11, 8 / 11]),
+        atol=0.003,
+    )
+    assert frame_count == 5
+    assert duration == pytest.approx(5 / 24)
+    assert audio["sample_rate"] == 32000
+    assert audio["waveform"].shape == (1, 2, round(5 / 24 * 32000))
+    assert torch.count_nonzero(audio["waveform"]) == 0
+    assert data["facts"]["audio_source"] == "generated_silence"
+    assert data["facts"]["first_source_frame_index"] == 0
+    assert data["facts"]["last_source_frame_index"] == 8
+    assert data["claims"]["streaming_decode"] is False
+
+
+def test_source_media_window_short_policies_are_explicit():
+    frames = torch.rand((3, 32, 32, 3))
+    with pytest.raises(ValueError, match="too short"):
+        prepare_source_media_window(
+            frames,
+            24.0,
+            32,
+            32,
+            5,
+            0.0,
+            "strict",
+            "pad_silence",
+        )
+
+    selected, _audio, _count, _duration, report = prepare_source_media_window(
+        frames,
+        24.0,
+        32,
+        32,
+        5,
+        0.0,
+        "hold_last_frame",
+        "pad_silence",
+    )
+    assert selected.shape[0] == 5
+    assert torch.equal(selected[-1], selected[-2])
+    assert json.loads(report)["facts"]["held_video_frames"] == 2
+
+
+def test_source_media_window_audio_is_resampled_and_exactly_timed():
+    frames = torch.rand((60, 32, 32, 3))
+    source_audio = {
+        "waveform": torch.ones((1, 1, 32000)),
+        "sample_rate": 16000,
+    }
+    _frames, audio, frame_count, _duration, report = prepare_source_media_window(
+        frames,
+        24.0,
+        32,
+        32,
+        22,
+        0.5,
+        "strict",
+        "strict",
+        source_audio,
+    )
+    expected_samples = round(frame_count / 24 * 32000)
+    assert frame_count == 22
+    assert audio["waveform"].shape == (1, 2, expected_samples)
+    assert audio["sample_rate"] == 32000
+    assert json.loads(report)["facts"]["input_audio_sample_rate"] == 16000
+
+
+def test_prepare_exact_pair_preserves_storage_metadata_and_builds_masks():
+    video = make_video()
+    audio = make_audio()
+    video_latent = {"samples": video, "source_hash": "video", "shared": "video_wins"}
+    audio_latent = {"samples": audio, "audio_hash": "audio", "shared": "audio_loses"}
+
+    av, video_out, audio_out, report = prepare(video_latent, audio_latent)
+    out_video, out_audio = av["samples"].unbind()
+    video_mask, audio_mask = av["noise_mask"].unbind()
+    data = json.loads(report)
+
+    assert out_video.data_ptr() == video.data_ptr()
+    assert out_audio.data_ptr() == audio.data_ptr()
+    assert torch.all(video_mask == 0.5)
+    assert torch.all(audio_mask == 0.0)
+    assert av["source_hash"] == "video"
+    assert av["audio_hash"] == "audio"
+    assert av["shared"] == "video_wins"
+    assert video_out["samples"].data_ptr() == video.data_ptr()
+    assert audio_out["samples"].data_ptr() == audio.data_ptr()
+    assert data["facts"]["frame_count"] == 124
+    assert data["facts"]["expected_audio_t"] == 207
+    assert data["facts"]["audio_fit_action"] == "exact"
+    assert data["facts"]["metadata_conflicts_kept_from_video"] == ["shared"]
+    assert data["claims"]["memory_safe"] is False
+    assert data["claims"]["denoise_strength_is_calibrated_linear_weight"] is False
+    assert set(video_latent) == {"samples", "source_hash", "shared"}
+    assert set(audio_latent) == {"samples", "audio_hash", "shared"}
+
+
+def test_prepare_respects_existing_masks_before_stream_strength():
+    video = make_video()
+    audio = make_audio()
+    video_mask = torch.full((1, 1, 37, 4, 6), 0.4)
+    audio_mask = torch.full((1, 1, 2, 207), 0.25)
+    av, _, _, _ = prepare(
+        {"samples": video, "noise_mask": video_mask},
+        {"samples": audio, "noise_mask": audio_mask},
+        video_denoise_strength=0.5,
+        audio_mode="remix",
+        audio_denoise_strength=0.4,
+    )
+    out_video_mask, out_audio_mask = av["noise_mask"].unbind()
+    assert out_video_mask.shape == video.shape
+    assert out_audio_mask.shape == audio.shape
+    assert torch.allclose(out_video_mask, torch.full_like(video, 0.2))
+    assert torch.allclose(out_audio_mask, torch.full_like(audio, 0.1))
+
+
+def test_short_locked_audio_pads_only_tail_as_generatable():
+    audio = make_audio(latent_t=200)
+    av, _, audio_out, report = prepare(
+        {"samples": make_video()},
+        {"samples": audio},
+        audio_fit_policy="pad_to_video_generate_tail",
+    )
+    _video, out_audio = av["samples"].unbind()
+    _video_mask, audio_mask = av["noise_mask"].unbind()
+    data = json.loads(report)
+
+    assert out_audio.shape[-1] == 207
+    assert torch.all(out_audio[..., :200] == 2.0)
+    assert torch.all(out_audio[..., 200:] == 0.0)
+    assert torch.all(audio_mask[..., :200] == 0.0)
+    assert torch.all(audio_mask[..., 200:] == 1.0)
+    assert torch.equal(audio_out["samples"], out_audio)
+    assert data["facts"]["audio_fit_action"] == "padded_7_latent_steps_generate_tail"
+
+
+def test_long_audio_requires_explicit_trim_policy():
+    video_latent = {"samples": make_video()}
+    audio_latent = {"samples": make_audio(latent_t=210)}
+    with pytest.raises(ValueError, match="longer"):
+        prepare(video_latent, audio_latent)
+
+    av, _, _, report = prepare(
+        video_latent,
+        audio_latent,
+        audio_fit_policy="trim_to_video",
+    )
+    assert av["samples"].unbind()[1].shape[-1] == 207
+    assert json.loads(report)["facts"]["audio_fit_action"] == "trimmed_3_latent_steps"
+
+
+def test_prepare_can_replace_audio_of_existing_av_without_changing_video():
+    video = make_video(value=3.0)
+    old_audio = make_audio(value=4.0)
+    old_video_mask = torch.full_like(video, 0.8)
+    existing = {
+        "samples": comfy.nested_tensor.NestedTensor((video, old_audio)),
+        "noise_mask": comfy.nested_tensor.NestedTensor(
+            (old_video_mask, torch.ones_like(old_audio))
+        ),
+        "chain_id": "accepted-1",
+    }
+    replacement = make_audio(value=9.0)
+
+    av, _, _, report = prepare(
+        existing,
+        {"samples": replacement},
+        video_denoise_strength=0.5,
+    )
+    out_video, out_audio = av["samples"].unbind()
+    video_mask, _audio_mask = av["noise_mask"].unbind()
+    data = json.loads(report)
+
+    assert out_video.data_ptr() == video.data_ptr()
+    assert out_audio.data_ptr() == replacement.data_ptr()
+    assert torch.all(video_mask == 0.4)
+    assert av["chain_id"] == "accepted-1"
+    assert data["facts"]["input_video_was_av"] is True
+
+
+def test_match_video_policy_only_converts_audio_stream_dtype():
+    video = make_video(dtype=torch.float32)
+    audio = make_audio(dtype=torch.float16)
+    av, _, _, report = prepare({"samples": video}, {"samples": audio})
+    out_video, out_audio = av["samples"].unbind()
+
+    assert out_video.data_ptr() == video.data_ptr()
+    assert out_audio.dtype == torch.float32
+    assert json.loads(report)["facts"]["audio_converted_to_video"] is True
+
+    with pytest.raises(ValueError, match="strict mode"):
+        prepare(
+            {"samples": video},
+            {"samples": audio},
+            dtype_device_policy="strict",
+        )
+
+
+@pytest.mark.parametrize(
+    ("video", "audio", "message"),
+    [
+        (torch.zeros((1, 23, 37, 4, 6)), make_audio(), "24 channels"),
+        (make_video(latent_t=36), make_audio(), r"5n\+2"),
+        (make_video(), torch.zeros((1, 32, 1, 207)), "stereo dimension 2"),
+        (make_video().expand(2, -1, -1, -1, -1), make_audio(), "batch size 1"),
+    ],
+)
+def test_prepare_rejects_malformed_h3_streams(video, audio, message):
+    with pytest.raises(ValueError, match=message):
+        prepare({"samples": video}, {"samples": audio})
+
+
+def test_separate_is_vae_free_and_preserves_metadata_and_masks():
+    video = make_video()
+    audio = make_audio()
+    video_mask = torch.full_like(video, 0.3)
+    audio_mask = torch.full_like(audio, 0.7)
+    av = {
+        "samples": comfy.nested_tensor.NestedTensor((video, audio)),
+        "noise_mask": comfy.nested_tensor.NestedTensor((video_mask, audio_mask)),
+        "source_hash": "abc",
+    }
+
+    video_out, audio_out, report = separate_source_av_latent(av)
+    data = json.loads(report)
+
+    assert video_out["samples"].data_ptr() == video.data_ptr()
+    assert audio_out["samples"].data_ptr() == audio.data_ptr()
+    assert video_out["noise_mask"].data_ptr() == video_mask.data_ptr()
+    assert audio_out["noise_mask"].data_ptr() == audio_mask.data_ptr()
+    assert video_out["source_hash"] == audio_out["source_hash"] == "abc"
+    assert data["facts"]["frame_count"] == 124
+    assert data["facts"]["has_video_noise_mask"] is True
+    assert data["facts"]["has_audio_noise_mask"] is True
+
+
+def test_separate_rejects_mismatched_audio_clock():
+    av = {
+        "samples": comfy.nested_tensor.NestedTensor(
+            (make_video(), make_audio(latent_t=206))
+        )
+    }
+    with pytest.raises(ValueError, match="audio clock"):
+        separate_source_av_latent(av)
+
+
+def test_source_video_repaint_api_uses_prepared_latent_for_both_sampler_inputs():
+    root = Path(__file__).resolve().parents[1]
+    prompt = json.loads((root / "examples" / "source_video_repaint_api.json").read_text("utf-8"))
+    by_type = {node["class_type"]: node for node in prompt.values()}
+
+    window = by_type["MiniMaxH3SourceMediaWindowT8"]
+    prepare_node = by_type["MiniMaxH3SourceAVPrepareT8"]
+    dual_clock = by_type["MiniMaxH3DualClockSamplerT8"]
+    sampler = by_type["SamplerCustomAdvanced"]
+    conditioning = by_type["MiniMaxH3AudioConditioningT8"]
+
+    assert window["inputs"]["frames"] == ["2", 0]
+    assert window["inputs"]["source_audio"] == ["2", 1]
+    assert window["inputs"]["source_fps"] == ["2", 2]
+    assert prepare_node["inputs"]["video_mode"] == "remix"
+    assert prepare_node["inputs"]["audio_mode"] == "lock"
+    assert dual_clock["inputs"]["av_latent"] == ["8", 0]
+    assert sampler["inputs"]["latent_image"] == ["8", 0]
+    assert conditioning["inputs"]["task_type"] == "T2VA"
+    assert not any(node["class_type"].startswith("VHS_") for node in prompt.values())
+
+
+def test_source_video_repaint_frontend_workflow_has_bidirectional_links():
+    root = Path(__file__).resolve().parents[1]
+    workflow = json.loads(
+        (
+            root
+            / "examples"
+            / "workflows"
+            / "H3_Source_Video_Repaint_Stock20_EXP.json"
+        ).read_text("utf-8")
+    )
+    nodes = {node["id"]: node for node in workflow["nodes"]}
+    links = {link[0]: link for link in workflow["links"]}
+    types = {node["type"] for node in nodes.values()}
+
+    assert {
+        "LoadVideo",
+        "GetVideoComponents",
+        "MiniMaxH3SourceMediaWindowT8",
+        "MiniMaxH3SourceAVPrepareT8",
+        "SamplerCustomAdvanced",
+        "MiniMaxH3AVDecodeT8",
+        "SaveVideo",
+    } <= types
+    assert not any(node_type.startswith("VHS_") for node_type in types)
+
+    for link_id, origin_id, origin_slot, target_id, target_slot, link_type in workflow["links"]:
+        assert links[link_id][5] == link_type
+        assert link_id in nodes[origin_id]["outputs"][origin_slot]["links"]
+        assert nodes[target_id]["inputs"][target_slot]["link"] == link_id


### PR DESCRIPTION
## What changed

- add three isolated experimental Source AV nodes for 24fps media windowing, strict H3 video/audio latent assembly, per-stream lock/remix/regenerate masks, and VAE-free AV separation
- append the new nodes after the existing 48 registrations so prior node IDs, ordering, defaults, and workflows remain unchanged
- add API and frontend example workflows
- update project metadata and README to version 1.11.0

## Validation

- 222 tests passed
- Ruff, compileall, JSON validation, and `git diff --check` passed
- isolated ComfyUI registration and workflow conversion passed
- one real H3 mechanical end-to-end probe produced a 124-frame 24fps H.264 video with 32kHz stereo AAC

## Limits

The real probe reached only 44.52 MiB minimum free VRAM on a 16 GiB GPU, below the 512 MiB safety gate. The nodes remain Experimental and do not claim `memory_safe`, calibrated denoise strength, arbitrary-video support, or perceptual quality validation.