### PR TITLE
Add dialogue-safe audio workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MiniMax H3 Audio T8
 
-面向当前 ComfyUI 原生 MiniMax H3 的独立 T8 节点扩展。当前版本为 `1.11.0`，共注册
-51 个节点，覆盖原生音画条件、来源视频音画重绘准备、音频控制与后处理、稳定双时钟采样、实验性多速率采样、
+面向当前 ComfyUI 原生 MiniMax H3 的独立 T8 节点扩展。当前版本为 `1.12.0`，共注册
+54 个节点，覆盖原生音画条件、对白边界分析、对白安全分轨混音、分时背景底轨锁定、来源视频音画重绘准备、音频控制与后处理、稳定双时钟采样、实验性多速率采样、
 隔离的分段长视频续写、总时长编排、候选/接受状态与文件级合成、Ref2VA 单图/多图
 参考的静态语义编辑，以及带异常释放保护、持久分段、精确时长后期和显式音色库的实验性语音链。
 
@@ -30,7 +30,9 @@ MiniMax H3 实现；可选语音校验才延迟导入 `faster-whisper` 或 `tran
 `cbbc9dab1`，运行环境为 Python 3.10+。模型、VAE、CLIP 和可选 LoRA
 仍需按具体任务自行安装。
 
-`1.11.0` 保留此前48个节点的 ID、顺序、默认值和旧接线，只在末尾追加3个完全隔离的 Source AV
+`1.12.0` 保留此前51个节点的 ID、顺序、默认值和旧接线，只在末尾追加3个完全隔离的
+Dialogue Safe Audio EXP 节点；旧工作流不会自动运行 ASR、改变联合 latent、分离混合音轨或
+替换最终音频。`1.11.0` 保留此前48个节点的 ID、顺序、默认值和旧接线，只在末尾追加3个完全隔离的 Source AV
 EXP 节点；旧工作流不会自动读取来源视频、改变 latent 或启用重绘 mask。`1.10.0` 保留此前36个节点的 ID、顺序、默认值和旧接线，只在其后追加12个语音可靠性/
 创作 EXP 节点；旧工作流不会自动启用异常全局卸载、持久音色库、长文本或 Joint 多人。
 `1.9.0` 只在原35个节点之后追加一个视觉参考强度 EXP 后置节点；原节点 ID、顺序、默认值和
@@ -95,6 +97,9 @@ VideoHelperSuite 的延迟 `AUDIO Mapping`，用 H3 latent 契约识别视频/�
 | MiniMax H3 Speech Assemble / 语音合成 (EXP/T8) | 以绝对 sample 时间轴合并多段、停顿、重叠、淡化、声像和增益 |
 | MiniMax H3 Dialogue Script / 对白脚本 (EXP/T8) | 把2–3个角色的普通文本或 JSON 变成逐 turn 对白计划 |
 | MiniMax H3 Dialogue Turn Select / 对白段选择 (EXP/T8) | 逐 turn 选择正确角色档案和单段语音计划，避免把未验证联合多人模式当稳定能力 |
+| MiniMax H3 Dialogue Boundary Analyzer / 对白边界分析 (EXP/T8) | 本地 CPU ASR 仅在出现唯一、连续、精确目标词序列时报告边界；重复目标或被插话打断时拒绝猜测 |
+| MiniMax H3 Dialogue Safe Master / 对白安全混音 (EXP/T8) | 把已验收的独立对白 stem 与独立音乐、环境和 SFX 组成完整时长母带，不在对白结束处截断背景声 |
+| MiniMax H3 Timed Background Bed Lock / 分时背景底轨锁定 (EXP/T8) | 两遍 H3 路线：用独立完整背景底轨替换音频 latent，并在显式对白边界后锁住底轨尾段 |
 | MiniMax H3 Speech Finalize / 语音完成与释放 (EXP/T8) | AUDIO 直通后执行 keep/cache-clear/全局卸载策略，并明确报告作用域 |
 | MiniMax H3 Speech Studio / 语音工作台 (EXP/T8) | GraphBuilder 一站式串起条件、stock采样、音频解码、校验和释放 |
 | MiniMax H3 Speech Abnormal-Exit Guard / 异常释放保护 (EXP/T8) | 在条件节点前登记 prompt 生命周期；异常、取消或非 OOM 错误令 Finalize 未执行时补发释放请求 |
@@ -195,6 +200,50 @@ API 示例：`examples/ref2va_visual_reference_strength_exp_api.json`；可拖�
 `0.995～0.950` 会改变姿态、表情、动作轨迹或构图，`0.950` 的输出偏移最大，面部高频代理还
 低于 `0.999`。因此节点只适合受控 A/B；不能把某个默认值宣传成稳定修复。当前矩阵的最小
 显存余量约35MiB，远低于项目512MiB安全门槛，也不能据此称16GB安全档。
+
+## EXP：对白结束后保留完整背景声
+
+这里处理的是一个与普通语音裁切不同的问题：H3 的最终音频往往是对白、音乐、环境声和音效的
+同一条立体声母带。如果模型在目标台词之后继续念叨，直接把整条母带裁到台词结束会同时删除
+后续音乐、环境和音效；当前节点不会用这种方式假装修复成功。
+
+`1.12.0` 提供三层、默认拒绝猜测的实验能力：
+
+1. `Dialogue Boundary Analyzer` 使用用户本地的 faster-whisper，在且仅在 ASR 中找到一个连续、
+   完整且唯一的目标词序列时报告边界。目标重复两次、目标被额外台词插断或未找到时都不选
+   “第一个/最后一个”；尾部能量只报告“还有信号”，不会把音乐或音效误判成语音。
+2. 推荐的确定性路线是“对白 stem 与背景 stem 分开生成/准备”。`Dialogue Safe Master` 要求
+   上游传入已验收的独立对白，并将独立音乐、环境和 SFX 放到目标 sample 时间线上。默认
+   `strict` 不会暗中循环、补零或截断任何已连接 stem；只有用户显式选择策略才会调整。最终
+   母带保持完整时长，对白结束后背景 stem 继续存在。
+3. 如果创作流程必须走联合 H3，可使用两遍生成：先准备一条不含对白、完整时长的背景底轨，
+   再由 `Timed Background Bed Lock` 编码成音频 latent；边界之前允许 H3 生成对白，边界之后
+   默认 `tail_denoise_strength=0` 锁住背景底轨。它保留原视频流和已有视频 mask；已有音频 mask
+   只作为上限，不会被节点偷偷放宽。
+
+真实机械探针使用当前 FL2VA pruned INT8、256×256、124帧、稳定双时钟4步。标准124帧 Audio
+Window 经真实音频 VAE 编码得到206步，而联合 H3 时钟需要207步，因此 `strict` 会正确拒绝；
+示例显式使用 `fit_reported`，记录补1个零 latent 步。4步采样后，2秒前可编辑头部相对底轨
+latent 的平均绝对变化为 `0.50223`，2秒后锁定尾部的最大绝对误差为 `2.38e-7`，在 `1e-6`
+绝对容差内保持。解码对照同时发现音频 VAE 的时间感受野会让边界后最初约0.3秒仍受头部变化
+影响；从2.3秒起100ms窗的最大差异降到约 `3.97e-4` 或更低。这证明 mask 机械生效，但不是
+“样本级硬切”“绝对无接缝”或主观质量保证。
+
+边界分析也在此前真实 Joint 两人失败样本上复测：一个样本的目标台词被额外内容插断，节点
+返回 `target_not_found`；另一个样本在17个多余词后出现唯一完整目标，节点报告7.00–9.72秒、
+`clean_exact=false`，而不是自动裁切或验收。ASR 会漏掉含混、非词汇人声，因此报告不是模型
+真值。
+
+当前没有集成自动源分离。机器虽安装了 `audio_separator` 包，但没有已选择/校验的分离权重；
+常见 vocal separator 以音乐人声/伴奏分离为目标，不等价于“只移除目标人物的额外对白”，还
+可能删除原本想保留的歌声或损伤音乐/SFX。必须先用合成可知真值与真实 H3 混音建立泄漏、
+音乐损伤和听评门槛，未过门槛前不会靠模型名猜一个默认分离器。
+
+示例：`examples/dialogue_safe_master_api.json`、
+`examples/workflows/H3_Dialogue_Safe_Master_EXP.json`，以及两遍 H3 的
+`examples/dialogue_timed_bed_lock_api.json`、
+`examples/workflows/H3_Dialogue_Timed_Background_Bed_Lock_EXP.json`。所有输入文件都是占位符；
+底轨必须是不含对白的独立完整背景，而不是已混合的 H3 最终母带。
 
 ## EXP：原生语音、参考音色与逐句对白
 
@@ -886,8 +935,8 @@ H3 的展示顺序是：所有 Picture；然后每个参考视频（其声轨 Au
 
 ## 示例与测试
 
-可直接拖入画布的稳定 4/4、三种输入音频模式、EXP 4/8、EXP 4/10、Ref2VA 22帧静态候选编辑，
-以及以下长视频示例位于 `examples/workflows/`：
+可直接拖入画布的稳定 4/4、三种输入音频模式、EXP 4/8、EXP 4/10、Ref2VA 22帧静态候选编辑、
+对白安全分轨母带、两遍 H3 分时背景底轨锁定，以及以下长视频示例位于 `examples/workflows/`：
 
 - `H3_Long_Video_22F_EXP.json`：手工逐段续写基线。
 - `H3_Long_Video_Accepted_22F_EXP.json`：候选预览、接受和可恢复状态链。
@@ -897,7 +946,9 @@ H3 的展示顺序是：所有 Picture；然后每个参考视频（其声轨 Au
 
 API 示例见 `examples/audio_lock_api.json`、
 `examples/dual_clock_4step_api.json`、`examples/multirate_exp_api.json` 和
-`examples/still_image_edit_api.json`。替换 API 示例里的模型、VAE、CLIP、可选 LoRA、
+`examples/still_image_edit_api.json`；对白安全音频另见
+`examples/dialogue_safe_master_api.json` 与 `examples/dialogue_timed_bed_lock_api.json`。
+替换 API 示例里的模型、VAE、CLIP、可选 LoRA、
 输入图像和音频文件名后即可使用；
 保存节点使用已安装的 VideoHelperSuite。
 

--- a/dialogue_audio.py
+++ b/dialogue_audio.py
@@ -1,0 +1,308 @@
+from __future__ import annotations
+
+import json
+import math
+from typing import Mapping
+
+import torch
+import torch.nn.functional as torch_functional
+import torchaudio
+
+from .core import validate_audio
+
+
+DIALOGUE_SAFE_MASTER_SCHEMA = "minimax_h3_t8_dialogue_safe_master_v1"
+BED_FIT_POLICIES = ("strict", "pad_or_trim", "loop_crossfade")
+SFX_FIT_POLICIES = ("strict", "pad_or_trim")
+
+
+def _json(value) -> str:
+    return json.dumps(value, ensure_ascii=False, indent=2, default=str)
+
+
+def _to_stereo(waveform: torch.Tensor) -> torch.Tensor:
+    if waveform.shape[1] == 2:
+        return waveform
+    if waveform.shape[1] == 1:
+        return waveform.expand(-1, 2, -1)
+    return waveform.mean(dim=1, keepdim=True).expand(-1, 2, -1)
+
+
+def _prepare_audio(audio: Mapping, name: str, output_sample_rate: int) -> torch.Tensor:
+    waveform, sample_rate = validate_audio(audio, name)
+    output = waveform.detach().to(device="cpu", dtype=torch.float32)
+    if sample_rate != output_sample_rate:
+        output = torchaudio.functional.resample(output, sample_rate, output_sample_rate)
+    return _to_stereo(output).contiguous()
+
+
+def _fade_curve(length: int, fade_in: bool) -> torch.Tensor:
+    if length <= 0:
+        return torch.empty(0, dtype=torch.float32)
+    phase = torch.linspace(0.0, math.pi / 2.0, length, dtype=torch.float32)
+    curve = phase.sin().square()
+    return curve if fade_in else curve.flip(0)
+
+
+def _loop_crossfade(
+    waveform: torch.Tensor,
+    target_samples: int,
+    crossfade_samples: int,
+) -> tuple[torch.Tensor, int, int]:
+    source_samples = waveform.shape[-1]
+    if source_samples >= target_samples:
+        return waveform[..., :target_samples].clone(), 1, 0
+    overlap = min(crossfade_samples, source_samples // 4)
+    if overlap <= 0:
+        raise ValueError("loop_crossfade requires a connected stem long enough for a crossfade")
+    output = waveform.clone()
+    repeats = 1
+    while output.shape[-1] < target_samples:
+        actual_overlap = min(overlap, output.shape[-1], waveform.shape[-1])
+        cross = (
+            output[..., -actual_overlap:] * _fade_curve(actual_overlap, False)
+            + waveform[..., :actual_overlap] * _fade_curve(actual_overlap, True)
+        )
+        output = torch.cat(
+            (output[..., :-actual_overlap], cross, waveform[..., actual_overlap:]),
+            dim=-1,
+        )
+        repeats += 1
+    return output[..., :target_samples].contiguous(), repeats, overlap
+
+
+def _fit_bed(
+    audio: Mapping | None,
+    name: str,
+    policy: str,
+    output_sample_rate: int,
+    target_samples: int,
+    loop_crossfade_seconds: float,
+) -> tuple[torch.Tensor, dict]:
+    if audio is None:
+        return torch.zeros((1, 2, target_samples), dtype=torch.float32), {
+            "connected": False,
+            "policy": policy,
+            "action": "missing_stem_is_silence",
+            "input_samples": 0,
+            "output_samples": target_samples,
+        }
+    waveform = _prepare_audio(audio, name, output_sample_rate)
+    source_samples = waveform.shape[-1]
+    if source_samples == target_samples:
+        return waveform, {
+            "connected": True,
+            "policy": policy,
+            "action": "exact",
+            "input_samples": source_samples,
+            "output_samples": target_samples,
+        }
+    if policy == "strict":
+        raise ValueError(
+            f"{name} has {source_samples} samples after resampling but the target master requires "
+            f"{target_samples}; choose an explicit fit policy"
+        )
+    if policy == "pad_or_trim":
+        if source_samples < target_samples:
+            output = torch_functional.pad(waveform, (0, target_samples - source_samples))
+            action = f"padded_{target_samples - source_samples}_samples_with_silence"
+        else:
+            output = waveform[..., :target_samples].contiguous()
+            action = f"trimmed_{source_samples - target_samples}_tail_samples"
+        return output, {
+            "connected": True,
+            "policy": policy,
+            "action": action,
+            "input_samples": source_samples,
+            "output_samples": target_samples,
+        }
+    if policy == "loop_crossfade":
+        output, repeats, overlap = _loop_crossfade(
+            waveform,
+            target_samples,
+            round(loop_crossfade_seconds * output_sample_rate),
+        )
+        return output, {
+            "connected": True,
+            "policy": policy,
+            "action": "looped_with_crossfade",
+            "input_samples": source_samples,
+            "output_samples": target_samples,
+            "repeat_count": repeats,
+            "crossfade_samples": overlap,
+            "crossfade_seconds": overlap / output_sample_rate,
+        }
+    raise ValueError(f"unknown {name} fit policy: {policy}")
+
+
+def _dbfs(value: float) -> float:
+    return 20.0 * math.log10(max(float(value), 1e-12))
+
+
+def build_dialogue_safe_master(
+    speech_audio: Mapping,
+    speech_accepted: bool,
+    target_duration_seconds: float,
+    speech_start_seconds: float = 0.0,
+    output_sample_rate: int = 32000,
+    music_fit_policy: str = "strict",
+    ambience_fit_policy: str = "strict",
+    sfx_fit_policy: str = "strict",
+    loop_crossfade_seconds: float = 0.25,
+    speech_gain_db: float = 0.0,
+    music_gain_db: float = 0.0,
+    ambience_gain_db: float = 0.0,
+    sfx_gain_db: float = 0.0,
+    duck_background: float = 0.0,
+    peak_limit_dbfs: float = -1.0,
+    music_audio: Mapping | None = None,
+    ambience_audio: Mapping | None = None,
+    sfx_audio: Mapping | None = None,
+):
+    if not bool(speech_accepted):
+        raise ValueError(
+            "Dialogue Safe Master requires a true accepted signal from exact speech verification; "
+            "it will not guess whether a speech stem is clean"
+        )
+    if output_sample_rate not in {32000, 44100, 48000}:
+        raise ValueError("output_sample_rate must be 32000, 44100, or 48000")
+    if not math.isfinite(float(target_duration_seconds)) or target_duration_seconds <= 0.0:
+        raise ValueError("target_duration_seconds must be positive")
+    if not math.isfinite(float(speech_start_seconds)) or speech_start_seconds < 0.0:
+        raise ValueError("speech_start_seconds must be nonnegative")
+    if music_fit_policy not in BED_FIT_POLICIES:
+        raise ValueError("unknown music_fit_policy")
+    if ambience_fit_policy not in BED_FIT_POLICIES:
+        raise ValueError("unknown ambience_fit_policy")
+    if sfx_fit_policy not in SFX_FIT_POLICIES:
+        raise ValueError("sfx_fit_policy must be strict or pad_or_trim; sound effects are never looped")
+    if not 0.0 <= float(loop_crossfade_seconds) <= 5.0:
+        raise ValueError("loop_crossfade_seconds must be between 0 and 5")
+    if not 0.0 <= float(duck_background) <= 1.0:
+        raise ValueError("duck_background must be between 0 and 1")
+    if not -24.0 <= float(peak_limit_dbfs) <= 0.0:
+        raise ValueError("peak_limit_dbfs must be between -24 and 0")
+    gains = {
+        "speech": float(speech_gain_db),
+        "music": float(music_gain_db),
+        "ambience": float(ambience_gain_db),
+        "sfx": float(sfx_gain_db),
+    }
+    if any(not -60.0 <= gain <= 24.0 for gain in gains.values()):
+        raise ValueError("stem gains must be between -60 and +24 dB")
+
+    target_samples = round(float(target_duration_seconds) * output_sample_rate)
+    if target_samples <= 0:
+        raise ValueError("target duration produced no audio samples")
+    speech = _prepare_audio(speech_audio, "speech_audio", output_sample_rate)
+    speech_start = round(float(speech_start_seconds) * output_sample_rate)
+    speech_end = speech_start + speech.shape[-1]
+    if speech_end > target_samples:
+        raise ValueError(
+            f"verified speech ends at sample {speech_end}, beyond target master sample "
+            f"{target_samples}; regenerate, shorten the line, or move it earlier"
+        )
+    speech_stem = torch.zeros((1, 2, target_samples), dtype=torch.float32)
+    speech_stem[..., speech_start:speech_end] = speech
+    speech_stem *= 10.0 ** (gains["speech"] / 20.0)
+
+    music, music_report = _fit_bed(
+        music_audio,
+        "music_audio",
+        music_fit_policy,
+        output_sample_rate,
+        target_samples,
+        loop_crossfade_seconds,
+    )
+    ambience, ambience_report = _fit_bed(
+        ambience_audio,
+        "ambience_audio",
+        ambience_fit_policy,
+        output_sample_rate,
+        target_samples,
+        loop_crossfade_seconds,
+    )
+    sfx, sfx_report = _fit_bed(
+        sfx_audio,
+        "sfx_audio",
+        sfx_fit_policy,
+        output_sample_rate,
+        target_samples,
+        loop_crossfade_seconds,
+    )
+    music *= 10.0 ** (gains["music"] / 20.0)
+    ambience *= 10.0 ** (gains["ambience"] / 20.0)
+    sfx *= 10.0 ** (gains["sfx"] / 20.0)
+    background = music + ambience + sfx
+
+    if duck_background > 0.0:
+        envelope = speech_stem.abs().mean(dim=1, keepdim=True)
+        window = max(1, round(output_sample_rate * 0.02))
+        envelope = torch_functional.avg_pool1d(
+            envelope,
+            window,
+            stride=1,
+            padding=window // 2,
+        )[..., :target_samples]
+        activity = (envelope / 0.05).clamp(0.0, 1.0)
+        background *= 1.0 - float(duck_background) * activity
+
+    master = speech_stem + background
+    peak_before = float(master.abs().amax())
+    limit = 10.0 ** (float(peak_limit_dbfs) / 20.0)
+    limiter_gain = min(1.0, limit / max(peak_before, 1e-12))
+    speech_stem *= limiter_gain
+    background *= limiter_gain
+    master = speech_stem + background
+    reconstruction_error = float((master - (speech_stem + background)).abs().amax())
+    report = {
+        "schema": DIALOGUE_SAFE_MASTER_SCHEMA,
+        "status": "sample_exact_stem_master",
+        "sample_rate": output_sample_rate,
+        "target_duration_seconds": float(target_duration_seconds),
+        "target_samples": target_samples,
+        "output_samples": int(master.shape[-1]),
+        "exact_sample_error": int(master.shape[-1]) - target_samples,
+        "speech": {
+            "accepted_input_required": True,
+            "start_sample": speech_start,
+            "end_sample": speech_end,
+            "start_seconds": speech_start / output_sample_rate,
+            "end_seconds": speech_end / output_sample_rate,
+            "input_samples_after_resample": int(speech.shape[-1]),
+            "tail_samples_after_speech": target_samples - speech_end,
+            "action": "placed_without_trimming_or_time_stretch",
+        },
+        "beds": {
+            "music": music_report,
+            "ambience": ambience_report,
+            "sfx": sfx_report,
+        },
+        "gains_db": gains,
+        "duck_background": float(duck_background),
+        "peak_limit": {
+            "limit_dbfs": float(peak_limit_dbfs),
+            "peak_before_dbfs": _dbfs(peak_before),
+            "limiter_gain": limiter_gain,
+            "attenuation_db": _dbfs(limiter_gain),
+        },
+        "stem_reconstruction_max_abs_error": reconstruction_error,
+        "claims": {
+            "master_tail_was_truncated_at_dialogue_end": False,
+            "background_was_source_separated_from_a_mix": False,
+            "speech_text_was_inferred_by_this_node": False,
+            "sample_exact_duration": True,
+            "lip_sync_verified": False,
+        },
+        "limitations": [
+            "Connected music, ambience, and SFX must already be independent stems.",
+            "This node does not remove speech from an existing mixed master.",
+            "An upstream accepted boolean is an assertion from ASR/QA, not proof supplied by this mixer.",
+        ],
+    }
+    return (
+        {"waveform": master.contiguous(), "sample_rate": output_sample_rate},
+        {"waveform": speech_stem.contiguous(), "sample_rate": output_sample_rate},
+        {"waveform": background.contiguous(), "sample_rate": output_sample_rate},
+        _json(report),
+    )

--- a/docs/README_ComfyUI.md
+++ b/docs/README_ComfyUI.md
@@ -75,6 +75,16 @@ the explicit dual-clock Euler/native-flow defaults. Lock mode routes the clean
 Conditioning `mux_audio` to the final MP4; remix and reference-only route decoded
 model audio instead. Upload or select a source file in `Load Audio` before queuing.
 
+Version 1.12.0 also installs two opt-in dialogue-safe audio workflows without changing any old
+workflow: `H3_Dialogue_Safe_Master_EXP.json` accepts already independent speech/music/ambience/SFX
+stems and keeps the background running after verified speech ends;
+`H3_Dialogue_Timed_Background_Bed_Lock_EXP.json` is a two-pass H3 graph that locks an independent
+dialogue-free background bed after an explicit 40Hz latent boundary. The first path is sample-exact
+stem assembly. The second path is not source separation or a sample-exact cut: the real H3 Audio
+VAE encoded a standard 124-frame window to 206 steps against the 207-step AV clock, so the example
+explicitly selects `fit_reported`, and its decoder showed roughly 0.3 seconds of temporal influence
+after the latent boundary. Both workflows use placeholders that must be replaced before queuing.
+
 The project also includes the isolated experimental long-video workflow
 `examples/workflows/H3_Long_Video_22F_EXP.json` and API graph
 `examples/long_video_segment_api.json`. They plan and execute one bounded segment

--- a/docs/VERIFICATION_REPORT.md
+++ b/docs/VERIFICATION_REPORT.md
@@ -5,10 +5,60 @@ verification checkpoint. For the current plugin version, node inventory, and
 Ref2VA still-image status, also read the project-root `README.md` and
 `features.json`.
 
-The current 1.9.0 checkpoint was verified on 2026-08-10 against ComfyUI `0.31.0` at
+The current 1.12.0 checkpoint was verified on 2026-08-10 against ComfyUI `0.31.0` at
 `cbbc9dab1f03d0d9a6caa8a8be7d77a7e37e1e44`. Historical LoRA conversion evidence below was
 originally recorded on 2026-08-06 against source commit
 `563b98eefbe643a4cd510ee7f0b43e79880d5a3f`.
+
+## 1.12.0 experimental dialogue-safe audio checkpoint
+
+Three nodes were appended after the prior 51-node inventory. No old node ID, order, default,
+schema prefix, or execution path changed:
+
+- `MiniMaxH3DialogueBoundaryAnalyzerT8` performs read-only local CPU faster-whisper analysis. It
+  returns a boundary only for exactly one contiguous exact normalized target sequence; zero or
+  multiple exact spans are rejected. Signal energy after the boundary is reported as activity,
+  not classified as speech.
+- `MiniMaxH3DialogueSafeMasterT8` requires an upstream accepted boolean and independent stems. It
+  places verified speech on an exact sample timeline and preserves full-duration music, ambience,
+  and SFX after speech ends. Strict is the default fit policy; loop/pad/trim only occur when the
+  user explicitly selects and receives a report for them.
+- `MiniMaxH3TimedAudioBedLockT8` is a two-pass H3 helper. It encodes an independent dialogue-free
+  background bed, preserves the input video stream/mask, and applies a 40Hz audio mask with a
+  default zero-denoise tail. Existing audio masks are caps, so the node never increases generation
+  freedom in an already constrained interval.
+
+Model-free boundary, mixing, mask, immutability, strict-fit, explicit-fit, and registration tests
+passed. A real FL2VA pruned INT8, Qwen3-VL NVFP4, H3 Audio VAE, 256x256, 124-frame, stable
+dual-clock four-step forward also passed. The standard 124-frame Audio Window encoded to 206 audio
+latent steps against the AV clock's 207, so strict mode deliberately failed and `fit_reported`
+explicitly zero-padded one step. Comparing saved audio latents before and after sampling at the
+2.0-second/step-80 lock boundary produced:
+
+| Region | Mean absolute change | Maximum absolute change |
+|---|---:|---:|
+| editable head, steps 0–79 | 0.502230 | 2.402396 |
+| locked tail, steps 80–206 | 1.81e-8 | 2.38e-7 |
+
+The locked tail therefore remained within `1e-6` absolute tolerance across four sampler steps,
+while the head materially changed. This establishes the latent-mask endpoint mechanically, not
+decoded perceptual quality. The same Audio VAE decoded both latents to 165,600 samples at 32kHz.
+The first 100ms after the 2.0-second boundary still had a 0.34177 maximum difference, and decoder
+influence decayed through roughly 2.3 seconds; later 100ms windows were approximately `3.97e-4` or
+lower in maximum difference. A latent boundary is therefore not a sample-exact audio cut and is
+not advertised as seamless.
+
+The read-only analyzer was also run against two prior real Joint-dialogue failures using the local
+multilingual small model. When unwanted words interrupted the expected sequence, it returned
+`target_not_found`. When 17 unwanted units preceded one contiguous exact target, it returned
+7.00–9.72 seconds with `clean_exact=false`; it did not auto-trim or accept the mixed result.
+
+Automatic source separation remains deliberately absent. The installed `audio_separator` Python
+package has no selected local model, and common vocal/music separators are not evidence of safe
+target-dialogue removal from a master containing intentional singing, music, ambience, and SFX.
+Synthetic known-stem leakage/damage tests, real H3 mixes, and listening gates are required before
+any separator can become an opt-in experiment. No speech-stop, mouth-stop, seamless-tail,
+source-separation, or 16GiB `memory_safe` claim is made.
 
 ## 1.9.0 experimental visual-reference strength checkpoint
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,6 +34,22 @@ Still Preflight 输出检查报告。需要把 LoadImage 的占位文件名替�
   时间轴合成的双人对白。它没有使用未经验证的单次联合多人生成；两个分支都会占用同一 H3，
   由 ComfyUI 串行执行，最后一个 Finalize 才做全局卸载。
 
+对白结束后保留完整背景声提供两套独立示例：
+
+- `dialogue_safe_master_api.json` / `workflows/H3_Dialogue_Safe_Master_EXP.json`：输入已验收的
+  独立对白、音乐、环境和 SFX stems；本地 ASR 只有在整条对白 stem 恰好包含一个完整目标时
+  才把 `clean_exact` 接给安全混音。默认 strict 要求三个背景 stem 已经是完整目标时长，最终
+  母带不会随对白结束而截断。
+- `dialogue_timed_bed_lock_api.json` /
+  `workflows/H3_Dialogue_Timed_Background_Bed_Lock_EXP.json`：两遍 H3 路线。输入一条不含对白的
+  完整背景底轨，2秒前允许 H3 生成，2秒后以0 denoise锁住底轨 latent。标准124帧窗口的真实
+  Audio VAE 会产生206步而联合时钟需要207步，所以示例有意使用 `fit_reported` 并报告补1步；
+  这不是静默时长修正。
+
+两者都不能把已混合的 H3 母带自动拆成人声、音乐和音效。前者是 sample 精确分轨合成；后者
+只有40Hz latent边界，并且真实解码探针在边界后约0.3秒观察到 VAE 时间感受野影响。不要把
+它们描述成源分离、无接缝硬切或角色闭嘴保证。
+
 三类语音功能也分别提供 ComfyUI 0.4 画布工作流：
 
 - `workflows/H3_Speech_Described_Stock20_EXP.json`：描述音色单句，默认不运行可选 QA；
@@ -71,6 +87,8 @@ Still Preflight 输出检查报告。需要把 LoadImage 的占位文件名替�
 - `H3_Speech_Described_Stock20_EXP.json`：描述音色的 stock20 实验语音；
 - `H3_Speech_Reference_Clone_Stock20_EXP.json`：有授权参考音色、ASR裁切与speaker报告；
 - `H3_Speech_Dialogue_Two_Speaker_Stock20_EXP.json`：两角色逐turn生成、sample级合成并统一释放。
+- `H3_Dialogue_Safe_Master_EXP.json`：唯一精确目标边界检查后，把独立 stems 合成完整时长母带；
+- `H3_Dialogue_Timed_Background_Bed_Lock_EXP.json`：两遍 H3 的40Hz分时背景底轨锁定。
 
 三份音画画布工作流使用相同 seed、prompt、EMA LoRA 和输出设置，便于直接比较。它们已写入
 当前 T8 安装中实际存在的非裁剪 H3 INT8 基模、NVFP4 H3 文本编码器和两套 VAE 文件名，

--- a/examples/dialogue_safe_master_api.json
+++ b/examples/dialogue_safe_master_api.json
@@ -1,0 +1,73 @@
+{
+  "1": {
+    "class_type": "LoadAudio",
+    "inputs": {"audio": "replace_with_verified_speech_stem.wav"},
+    "_meta": {"title": "Load an independent speech stem; do not use a mixed H3 master"}
+  },
+  "2": {
+    "class_type": "LoadAudio",
+    "inputs": {"audio": "replace_with_exact_duration_music_bed.wav"},
+    "_meta": {"title": "Load exact-duration music stem"}
+  },
+  "3": {
+    "class_type": "LoadAudio",
+    "inputs": {"audio": "replace_with_exact_duration_ambience.wav"},
+    "_meta": {"title": "Load exact-duration ambience stem"}
+  },
+  "4": {
+    "class_type": "LoadAudio",
+    "inputs": {"audio": "replace_with_exact_duration_sound_effects.wav"},
+    "_meta": {"title": "Load exact-duration SFX stem"}
+  },
+  "5": {
+    "class_type": "PrimitiveStringMultiline",
+    "inputs": {"value": "The light is on."},
+    "_meta": {"title": "Exact expected dialogue"}
+  },
+  "6": {
+    "class_type": "MiniMaxH3DialogueBoundaryAnalyzerT8",
+    "inputs": {
+      "audio": ["1", 0],
+      "expected_text": ["5", 0],
+      "asr_model_directory": "faster-whisper-small-multilingual-536b0662",
+      "language": "auto",
+      "beam_size": 5,
+      "cpu_threads": 8,
+      "unload_after_analyze": true,
+      "tail_activity_threshold_dbfs": -45.0
+    },
+    "_meta": {"title": "Require one unique exact target; repeated or extra words are rejected"}
+  },
+  "7": {
+    "class_type": "MiniMaxH3DialogueSafeMasterT8",
+    "inputs": {
+      "speech_audio": ["1", 0],
+      "speech_accepted": ["6", 2],
+      "target_duration_seconds": 10.0,
+      "speech_start_seconds": 0.0,
+      "output_sample_rate": 32000,
+      "music_fit_policy": "strict",
+      "ambience_fit_policy": "strict",
+      "sfx_fit_policy": "strict",
+      "loop_crossfade_seconds": 0.25,
+      "speech_gain_db": 0.0,
+      "music_gain_db": 0.0,
+      "ambience_gain_db": 0.0,
+      "sfx_gain_db": 0.0,
+      "duck_background": 0.25,
+      "peak_limit_dbfs": -1.0,
+      "music_audio": ["2", 0],
+      "ambience_audio": ["3", 0],
+      "sfx_audio": ["4", 0]
+    },
+    "_meta": {"title": "Build 10s master; dialogue ends but music, ambience and SFX continue"}
+  },
+  "8": {
+    "class_type": "SaveAudio",
+    "inputs": {
+      "audio": ["7", 0],
+      "filename_prefix": "MiniMaxH3_T8_DialogueSafe/dialogue_safe_master"
+    },
+    "_meta": {"title": "Save full-duration master"}
+  }
+}

--- a/examples/dialogue_timed_bed_lock_api.json
+++ b/examples/dialogue_timed_bed_lock_api.json
@@ -1,0 +1,152 @@
+{
+  "1": {
+    "class_type": "UNETLoader",
+    "inputs": {
+      "unet_name": "minimax_h3_fl2va_pruned_int8_convrot.safetensors",
+      "weight_dtype": "default"
+    },
+    "_meta": {"title": "Load H3 FL2VA pruned INT8"}
+  },
+  "2": {
+    "class_type": "LoraLoaderModelOnly",
+    "inputs": {
+      "model": ["1", 0],
+      "lora_name": "minimax_h3_turbo_4步加速ema_comfyui.safetensors",
+      "strength_model": 1.0
+    },
+    "_meta": {"title": "Load the existing Standard H3 four-step LoRA"}
+  },
+  "3": {
+    "class_type": "CLIPLoader",
+    "inputs": {
+      "clip_name": "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors",
+      "type": "minimax",
+      "device": "default"
+    },
+    "_meta": {"title": "Reuse H3 Qwen3-VL text encoder"}
+  },
+  "4": {
+    "class_type": "VAELoader",
+    "inputs": {"vae_name": "minimax_h3_video_vae_fp16.safetensors"},
+    "_meta": {"title": "Load H3 video VAE"}
+  },
+  "5": {
+    "class_type": "VAELoader",
+    "inputs": {"vae_name": "minimax_h3_audio_vae_fp32.safetensors"},
+    "_meta": {"title": "Load H3 audio VAE"}
+  },
+  "6": {
+    "class_type": "LoadAudio",
+    "inputs": {"audio": "replace_with_full_duration_background_bed.wav"},
+    "_meta": {"title": "Independent music + ambience + SFX bed; it must contain no dialogue"}
+  },
+  "7": {
+    "class_type": "MiniMaxH3AudioWindowT8",
+    "inputs": {
+      "audio": ["6", 0],
+      "scene_start_seconds": 0.0,
+      "scene_duration_seconds": 5.1666666667,
+      "warmup_seconds": 0.0,
+      "cooldown_seconds": 0.0,
+      "ensure_minimum_context": true
+    },
+    "_meta": {"title": "Normalize bed to a 124-frame H3 window"}
+  },
+  "8": {
+    "class_type": "MiniMaxH3AudioConditioningT8",
+    "inputs": {
+      "clip": ["3", 0],
+      "video_vae": ["4", 0],
+      "audio_vae": ["5", 0],
+      "prompt": "A quiet cinematic room. A person says exactly and only <d>The light is on.</d> After the final word the person stays silent and closes their mouth. Soft music, room ambience, and subtle sound effects continue naturally to the end.",
+      "width": 736,
+      "height": 416,
+      "length": ["7", 1],
+      "task_type": "T2VA",
+      "audio_mode": "native",
+      "audio_denoise_strength": 1.0,
+      "add_source_as_reference": false,
+      "prompt_primary_audio_ordinal": 0,
+      "strict_prompt_tags": true,
+      "ref_image_size": "match",
+      "reference_video_policy": "official_2_to_15s"
+    },
+    "_meta": {"title": "Generate dialogue only in the editable head interval"}
+  },
+  "9": {
+    "class_type": "PrimitiveFloat",
+    "inputs": {"value": 2.0},
+    "_meta": {"title": "Verified/planned dialogue end; latent lock is ceil-quantized to 40Hz"}
+  },
+  "10": {
+    "class_type": "MiniMaxH3TimedAudioBedLockT8",
+    "inputs": {
+      "av_latent": ["8", 1],
+      "background_audio": ["7", 0],
+      "audio_vae": ["5", 0],
+      "tail_lock_start_seconds": ["9", 0],
+      "head_denoise_strength": 1.0,
+      "tail_denoise_strength": 0.0,
+      "transition_seconds": 0.0,
+      "audio_latent_fit_policy": "fit_reported"
+    },
+    "_meta": {"title": "Two-pass lock; normal 124F audio VAE encoding needs one reported pad step"}
+  },
+  "11": {
+    "class_type": "MiniMaxH3DualClockSamplerT8",
+    "inputs": {
+      "model": ["2", 0],
+      "av_latent": ["10", 0],
+      "steps": 4,
+      "shift_video": 12.0,
+      "shift_audio": 3.0,
+      "sampler_name": "dual_clock_euler",
+      "scheduler": "native_flow"
+    },
+    "_meta": {"title": "Existing stable 4V/4A dual-clock defaults"}
+  },
+  "12": {
+    "class_type": "RandomNoise",
+    "inputs": {"noise_seed": 2608105101}
+  },
+  "13": {
+    "class_type": "BasicGuider",
+    "inputs": {"model": ["11", 0], "conditioning": ["8", 0]}
+  },
+  "14": {
+    "class_type": "SamplerCustomAdvanced",
+    "inputs": {
+      "noise": ["12", 0],
+      "guider": ["13", 0],
+      "sampler": ["11", 1],
+      "sigmas": ["11", 2],
+      "latent_image": ["10", 0]
+    }
+  },
+  "15": {
+    "class_type": "MiniMaxH3AVDecodeT8",
+    "inputs": {
+      "av_latent": ["14", 0],
+      "video_vae": ["4", 0],
+      "audio_vae": ["5", 0]
+    }
+  },
+  "16": {
+    "class_type": "VHS_VideoCombine",
+    "inputs": {
+      "images": ["15", 0],
+      "audio": ["15", 1],
+      "frame_rate": 24,
+      "loop_count": 0,
+      "filename_prefix": "MiniMaxH3_T8_DialogueSafe/timed_background_bed_lock",
+      "format": "video/h264-mp4",
+      "pix_fmt": "yuv420p",
+      "crf": 19,
+      "save_metadata": true,
+      "trim_to_audio": false,
+      "pingpong": false,
+      "save_output": true
+    },
+    "_meta": {"title": "Save full AV result; do not trim the master at the dialogue end"}
+  }
+}

--- a/examples/workflows/H3_Dialogue_Safe_Master_EXP.json
+++ b/examples/workflows/H3_Dialogue_Safe_Master_EXP.json
@@ -1,0 +1,665 @@
+{
+  "id": "3375ce4b-3509-40e5-bfff-ec25b85932a9",
+  "revision": 0,
+  "last_node_id": 8,
+  "last_link_id": 8,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "LoadAudio",
+      "title": "Load an independent speech stem; do not use a mixed H3 master",
+      "pos": [
+        0,
+        0
+      ],
+      "size": [
+        390,
+        124
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "COMBO",
+          "widget": {
+            "name": "audio"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "AUDIO",
+          "type": "AUDIO",
+          "links": [
+            1,
+            3
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "LoadAudio"
+      },
+      "widgets_values": [
+        "replace_with_verified_speech_stem.wav"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "LoadAudio",
+      "title": "Load exact-duration music stem",
+      "pos": [
+        0,
+        300
+      ],
+      "size": [
+        390,
+        124
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "COMBO",
+          "widget": {
+            "name": "audio"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "AUDIO",
+          "type": "AUDIO",
+          "links": [
+            5
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "LoadAudio"
+      },
+      "widgets_values": [
+        "replace_with_exact_duration_music_bed.wav"
+      ]
+    },
+    {
+      "id": 3,
+      "type": "LoadAudio",
+      "title": "Load exact-duration ambience stem",
+      "pos": [
+        0,
+        600
+      ],
+      "size": [
+        390,
+        124
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "COMBO",
+          "widget": {
+            "name": "audio"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "AUDIO",
+          "type": "AUDIO",
+          "links": [
+            6
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "LoadAudio"
+      },
+      "widgets_values": [
+        "replace_with_exact_duration_ambience.wav"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "LoadAudio",
+      "title": "Load exact-duration SFX stem",
+      "pos": [
+        0,
+        900
+      ],
+      "size": [
+        390,
+        124
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "COMBO",
+          "widget": {
+            "name": "audio"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "AUDIO",
+          "type": "AUDIO",
+          "links": [
+            7
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "LoadAudio"
+      },
+      "widgets_values": [
+        "replace_with_exact_duration_sound_effects.wav"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "PrimitiveStringMultiline",
+      "title": "Exact expected dialogue",
+      "pos": [
+        0,
+        1200
+      ],
+      "size": [
+        390,
+        124
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "value",
+          "type": "STRING",
+          "widget": {
+            "name": "value"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "STRING",
+          "type": "STRING",
+          "links": [
+            2
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "PrimitiveStringMultiline"
+      },
+      "widgets_values": [
+        "The light is on."
+      ]
+    },
+    {
+      "id": 6,
+      "type": "MiniMaxH3DialogueBoundaryAnalyzerT8",
+      "title": "Require one unique exact target; repeated or extra words are rejected",
+      "pos": [
+        440,
+        0
+      ],
+      "size": [
+        390,
+        396
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 1
+        },
+        {
+          "name": "expected_text",
+          "type": "STRING",
+          "link": 2
+        },
+        {
+          "name": "asr_model_directory",
+          "type": "STRING",
+          "widget": {
+            "name": "asr_model_directory"
+          },
+          "link": null
+        },
+        {
+          "name": "language",
+          "type": "COMBO",
+          "widget": {
+            "name": "language"
+          },
+          "link": null
+        },
+        {
+          "name": "beam_size",
+          "type": "INT",
+          "widget": {
+            "name": "beam_size"
+          },
+          "link": null
+        },
+        {
+          "name": "cpu_threads",
+          "type": "INT",
+          "widget": {
+            "name": "cpu_threads"
+          },
+          "link": null
+        },
+        {
+          "name": "unload_after_analyze",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "unload_after_analyze"
+          },
+          "link": null
+        },
+        {
+          "name": "tail_activity_threshold_dbfs",
+          "type": "FLOAT",
+          "widget": {
+            "name": "tail_activity_threshold_dbfs"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "transcript",
+          "type": "STRING",
+          "links": null
+        },
+        {
+          "name": "unique_target_found",
+          "type": "BOOLEAN",
+          "links": null
+        },
+        {
+          "name": "clean_exact",
+          "type": "BOOLEAN",
+          "links": [
+            4
+          ]
+        },
+        {
+          "name": "speech_start_seconds",
+          "type": "FLOAT",
+          "links": null
+        },
+        {
+          "name": "speech_end_seconds",
+          "type": "FLOAT",
+          "links": null
+        },
+        {
+          "name": "extra_before_units",
+          "type": "INT",
+          "links": null
+        },
+        {
+          "name": "extra_after_units",
+          "type": "INT",
+          "links": null
+        },
+        {
+          "name": "report_json",
+          "type": "STRING",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "minimax-h3-audio-T8",
+        "Node name for S&R": "MiniMaxH3DialogueBoundaryAnalyzerT8"
+      },
+      "widgets_values": [
+        "faster-whisper-small-multilingual-536b0662",
+        "auto",
+        5,
+        8,
+        true,
+        -45.0
+      ]
+    },
+    {
+      "id": 7,
+      "type": "MiniMaxH3DialogueSafeMasterT8",
+      "title": "Build 10s master; dialogue ends but music, ambience and SFX continue",
+      "pos": [
+        880,
+        0
+      ],
+      "size": [
+        390,
+        782
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "speech_audio",
+          "type": "AUDIO",
+          "link": 3
+        },
+        {
+          "name": "speech_accepted",
+          "type": "BOOLEAN",
+          "link": 4
+        },
+        {
+          "name": "target_duration_seconds",
+          "type": "FLOAT",
+          "widget": {
+            "name": "target_duration_seconds"
+          },
+          "link": null
+        },
+        {
+          "name": "speech_start_seconds",
+          "type": "FLOAT",
+          "widget": {
+            "name": "speech_start_seconds"
+          },
+          "link": null
+        },
+        {
+          "name": "output_sample_rate",
+          "type": "COMBO",
+          "widget": {
+            "name": "output_sample_rate"
+          },
+          "link": null
+        },
+        {
+          "name": "music_fit_policy",
+          "type": "COMBO",
+          "widget": {
+            "name": "music_fit_policy"
+          },
+          "link": null
+        },
+        {
+          "name": "ambience_fit_policy",
+          "type": "COMBO",
+          "widget": {
+            "name": "ambience_fit_policy"
+          },
+          "link": null
+        },
+        {
+          "name": "sfx_fit_policy",
+          "type": "COMBO",
+          "widget": {
+            "name": "sfx_fit_policy"
+          },
+          "link": null
+        },
+        {
+          "name": "loop_crossfade_seconds",
+          "type": "FLOAT",
+          "widget": {
+            "name": "loop_crossfade_seconds"
+          },
+          "link": null
+        },
+        {
+          "name": "speech_gain_db",
+          "type": "FLOAT",
+          "widget": {
+            "name": "speech_gain_db"
+          },
+          "link": null
+        },
+        {
+          "name": "music_gain_db",
+          "type": "FLOAT",
+          "widget": {
+            "name": "music_gain_db"
+          },
+          "link": null
+        },
+        {
+          "name": "ambience_gain_db",
+          "type": "FLOAT",
+          "widget": {
+            "name": "ambience_gain_db"
+          },
+          "link": null
+        },
+        {
+          "name": "sfx_gain_db",
+          "type": "FLOAT",
+          "widget": {
+            "name": "sfx_gain_db"
+          },
+          "link": null
+        },
+        {
+          "name": "duck_background",
+          "type": "FLOAT",
+          "widget": {
+            "name": "duck_background"
+          },
+          "link": null
+        },
+        {
+          "name": "peak_limit_dbfs",
+          "type": "FLOAT",
+          "widget": {
+            "name": "peak_limit_dbfs"
+          },
+          "link": null
+        },
+        {
+          "name": "music_audio",
+          "type": "AUDIO",
+          "link": 5
+        },
+        {
+          "name": "ambience_audio",
+          "type": "AUDIO",
+          "link": 6
+        },
+        {
+          "name": "sfx_audio",
+          "type": "AUDIO",
+          "link": 7
+        }
+      ],
+      "outputs": [
+        {
+          "name": "master_audio",
+          "type": "AUDIO",
+          "links": [
+            8
+          ]
+        },
+        {
+          "name": "speech_stem",
+          "type": "AUDIO",
+          "links": null
+        },
+        {
+          "name": "background_stem",
+          "type": "AUDIO",
+          "links": null
+        },
+        {
+          "name": "report_json",
+          "type": "STRING",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "minimax-h3-audio-T8",
+        "Node name for S&R": "MiniMaxH3DialogueSafeMasterT8"
+      },
+      "widgets_values": [
+        10.0,
+        0.0,
+        32000,
+        "strict",
+        "strict",
+        "strict",
+        0.25,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.25,
+        -1.0
+      ]
+    },
+    {
+      "id": 8,
+      "type": "SaveAudio",
+      "title": "Save full-duration master",
+      "pos": [
+        1320,
+        0
+      ],
+      "size": [
+        390,
+        150
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 8
+        },
+        {
+          "name": "filename_prefix",
+          "type": "STRING",
+          "widget": {
+            "name": "filename_prefix"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "SaveAudio"
+      },
+      "widgets_values": [
+        "MiniMaxH3_T8_DialogueSafe/dialogue_safe_master"
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      1,
+      0,
+      6,
+      0,
+      "AUDIO"
+    ],
+    [
+      2,
+      5,
+      0,
+      6,
+      1,
+      "STRING"
+    ],
+    [
+      3,
+      1,
+      0,
+      7,
+      0,
+      "AUDIO"
+    ],
+    [
+      4,
+      6,
+      2,
+      7,
+      1,
+      "BOOLEAN"
+    ],
+    [
+      5,
+      2,
+      0,
+      7,
+      15,
+      "AUDIO"
+    ],
+    [
+      6,
+      3,
+      0,
+      7,
+      16,
+      "AUDIO"
+    ],
+    [
+      7,
+      4,
+      0,
+      7,
+      17,
+      "AUDIO"
+    ],
+    [
+      8,
+      7,
+      0,
+      8,
+      0,
+      "AUDIO"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.75,
+      "offset": [
+        120,
+        120
+      ]
+    },
+    "workflow_title": "MiniMax H3 Dialogue Safe Master EXP"
+  },
+  "version": 0.4
+}

--- a/examples/workflows/H3_Dialogue_Timed_Background_Bed_Lock_EXP.json
+++ b/examples/workflows/H3_Dialogue_Timed_Background_Bed_Lock_EXP.json
@@ -1,0 +1,1386 @@
+{
+  "id": "b318fddf-9cbd-48b3-bddd-b5720cf5b858",
+  "revision": 0,
+  "last_node_id": 16,
+  "last_link_id": 24,
+  "nodes": [
+    {
+      "id": 1,
+      "type": "UNETLoader",
+      "title": "Load H3 FL2VA pruned INT8",
+      "pos": [
+        0,
+        0
+      ],
+      "size": [
+        390,
+        168
+      ],
+      "flags": {},
+      "order": 0,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "unet_name",
+          "type": "['CogVideoX_5b_fun_GGUF_Q4_0.safetensors', 'Comfy-hunyuan_video_image_to_video_720p_bf16.safetensors', 'ComfyUI_00001_.safetensors', 'FramePackI2V_HY_converted_experimental_fp8_e4m3fn.safetensors', 'FramePackI2V_HY_fp8_e4m3fn.safetensors', 'Framer_controlnet_fp16.safetensors', 'Framer_unet_fp16.safetensors', 'LongCat_TI2V_comfy_bf16.safetensors', 'MelBandRoformer_fp32.safetensors', 'Phantom-Wan-14B_fp8_e4m3fn.safetensors', 'Phantom-Wan-1_3B_fp16.safetensors', 'VACE1.3b.safetensors', 'Wan2.1-T2V-1.3B-Self-Forcing-DMD-VACE-FP16.safetensors', 'Wan2_1-Wan-I2V-ATI-14B_fp8_e4m3fn.safetensors', 'acestep_v1.5_turbo.safetensors', 'acestep_v1.5_xl_sft_bf16.safetensors', 'acestep_v1.5_xl_turbo_bf16.safetensors', 'aniWan2114BFp8E4m3fn_i2v480pNew.safetensors', 'anima-base-v1.0.safetensors', 'boogu_image_base_fp8_scaled.safetensors', 'boogu_image_edit_fp8_scaled.safetensors', 'boogu_image_turbo_fp8_scaled.safetensors', 'comfy-hunyuan_video_v2_replace_image_to_video_720p_bf16.safetensors', 'comfy-wan2.1_i2v_480p_14B_bf16 .safetensors', 'comfy-wan2.1_i2v_720p_14B_bf16.safetensors', 'comfy-wan2.1_t2v_1.3B_bf16.safetensors', 'comfy-wan2.1_t2v_14B_bf16.safetensors', 'hunyuan_video_720_cfgdistill_fp8_e4m3fn.safetensors', 'hunyuan_video_FastVideo_720_fp8_e4m3fn.safetensors', 'hunyuan_video_I2V_720_fixed_fp8_e4m3fn.safetensors', 'hunyuan_video_I2V_fp8_e4m3fn.safetensors', 'hunyuan_video_accvid-t2v-5-steps_fp8_e4m3fn.safetensors', 'hunyuan_video_custom_720p_fp8_scaled.safetensors', 'minimax_h3_fl2va_int8_convrot.safetensors', 'minimax_h3_fl2va_pruned_int8_convrot.safetensors', 'minimax_h3_ref2va_adaln_video_last8_g099.safetensors', 'minimax_h3_ref2va_adaln_video_last8_g101.safetensors', 'minimax_h3_ref2va_attn_last8_g102.safetensors', 'minimax_h3_ref2va_attn_last8_g105.safetensors', 'minimax_h3_ref2va_int8_convrot.safetensors', 'minimax_h3_ref2va_patchin_hf101.safetensors', 'minimax_h3_ref2va_patchin_hf102_T8.safetensors', 'minimax_h3_ref2va_patchio_hf101.safetensors', 'minimax_h3_ref2va_pruned_int8_convrot.safetensors', 'minimax_h3_ref2va_videohead_hf101.safetensors', 'minimax_h3_ref2va_videohead_hf102.safetensors', 'minimax_h3_ref2va_videohead_hf104.safetensors', 'mochi\\\\mochi_preview_dit_GGUF_Q4_0_v2.safetensors', 'mochi\\\\mochi_preview_dit_fp8_e4m3fn.safetensors', 'mp_rank_00_model_states.pt', 'mp_rank_00_model_states_fp8.pt', 'mp_rank_00_model_states_fp8_map.pt', 'n-wan_1.3B_e10.safetensors', 'nsfw_wan_14b_e1.safetensors', 'self_forcing_dmd.pt', 'skyreels_hunyuan_i2v_fp8_e4m3fn.safetensors', 'skyreels_hunyuan_t2v_fp8_e4m3fn.safetensors', 'svdq-fp4_r128-z-image-turbo.safetensors', 'svdq-int4_r128-z-image-turbo.safetensors', 'svdq-int4_r256-z-image-turbo.safetensors', 'wan_1.3B_e20.safetensors', 'wan_1.3B_exp_e14.safetensors', 'z-image-turbo-fp8-e4m3fn.safetensors', 'z_image_bf16.safetensors', 'z_image_turbo_bf16.safetensors']",
+          "widget": {
+            "name": "unet_name"
+          },
+          "link": null
+        },
+        {
+          "name": "weight_dtype",
+          "type": "['default', 'fp8_e4m3fn', 'fp8_e4m3fn_fast', 'fp8_e5m2']",
+          "widget": {
+            "name": "weight_dtype"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            1
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "UNETLoader"
+      },
+      "widgets_values": [
+        "minimax_h3_fl2va_pruned_int8_convrot.safetensors",
+        "default"
+      ]
+    },
+    {
+      "id": 2,
+      "type": "LoraLoaderModelOnly",
+      "title": "Load the existing Standard H3 four-step LoRA",
+      "pos": [
+        440,
+        0
+      ],
+      "size": [
+        390,
+        194
+      ],
+      "flags": {},
+      "order": 1,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 1
+        },
+        {
+          "name": "lora_name",
+          "type": "['111Apose_V7_dim4-hunyuan-video.safetensors', '14b_oil_motion_preview1.0.safetensors', '14b_oil_style_preview1.0.safetensors', '14b_oil_style_v2_preview1.0B.safetensors', '360度旋转.safetensors', 'FILM_NOIR_EPOCH10.safetensors', 'FastWan_T2V_14B_480p_lora_rank_128_bf16.safetensors', 'FastWan_T2V_14B_480p_lora_rank_16_bf16.safetensors', 'FastWan_T2V_14B_480p_lora_rank_64_bf16.safetensors', 'HYVrewardMPS_epoch40.safetensors', 'HunyuanVideo_dashtoon_keyframe_lora_converted_bf16.safetensors', 'LongCat_distill_lora_alpha64_bf16.safetensors', 'Phantom_Wan_14B_FusionX_LoRA.safetensors', 'UniAnimate-Wan2.1-14B-Lora-12000-fp16.safetensors', 'WAN2.1_SmartphoneSnapshotPhotoReality_v1_by-AI_Characters.safetensors', 'Wan2.1-Fun-1.3B-InP-HPS2.1.safetensors', 'Wan2.1-Fun-1.3B-InP-MPS.safetensors', 'Wan2.1-Fun-14B-InP-HPS2.1.safetensors', 'Wan2.1-Fun-14B-InP-MPS.safetensors', 'Wan2.1_I2V_14B_FusionX_LoRA.safetensors', 'Wan2.1_T2V_14B_FusionX_LoRA.safetensors', 'Wan2.2-Fun-A14B-InP-high-noise-HPS2.1.safetensors', 'Wan2.2-Fun-A14B-InP-high-noise-MPS.safetensors', 'Wan2.2-Fun-A14B-InP-low-noise-HPS2.1.safetensors', 'Wan2.2-Fun-A14B-InP-low-noise-MPS.safetensors', 'Wan2.2-Lightning_T2V-A14B-4steps-lora_HIGH_fp16.safetensors', 'Wan2.2-Lightning_T2V-A14B-4steps-lora_LOW_fp16.safetensors', 'Wan21_AccVid_T2V_14B_lora_rank32_fp16.safetensors', 'Wan21_CausVid_14B_T2V_lora_rank32.safetensors', 'Wan21_CausVid_bidirect2_T2V_1_3B_lora_rank32.safetensors', 'Wan21_I2V_14B_lightx2v_cfg_step_distill_lora_rank64.safetensors', 'Wan21_PusaV1_LoRA_14B_rank512_bf16.safetensors', 'Wan21_T2V_14B_lightx2v_cfg_step_distill_lora_rank32.safetensors', 'Wan22_A14B_T2V_HIGH_Lightning_4steps_lora_250928_rank128_fp16.safetensors', 'Wan22_A14B_T2V_LOW_Lightning_4steps_lora_250928_rank64_fp16.safetensors', 'Wan2_1_EchoShot_1_3B_lora_rank_128_fp16.safetensors', 'Wan2_1_self_forcing_dmd_1_3B_lora_rank_32_fp16.safetensors', 'Wan2_1_self_forcing_sid_v2_1_3B_lora_rank_32_fp16.safetensors', 'Wan_Breast_Helper_Hearmeman.safetensors', 'Wan_i2v_hadouken_v2_s1200.safetensors', 'body2img_V7_kisekaeichi_dim4_1e-3_512_768-000140.safetensors', 'boogu_image_turbo_lora_rank_128_bf16.safetensors', 'cakify_i2v_v2-wan.safetensors', 'chenyu.safetensors', 'chenyu2.safetensors', 'chenyu3.safetensors', 'embrace_kohaya_weights.safetensors', 'gao_6943.pt', 'gao_epo13.safetensors', 'gao_epo15.safetensors', 'gao_epoch4.safetensors', 'gao_epoch9.safetensors', 'hair_growth_kohaya_weights.safetensors', 'high_noise_model.safetensors', 'hunyuan_i2v544p_V2.safetensors', 'hunyuan_video_accvid_5_steps_lora_rank16_fp8_e4m3fn.safetensors', 'hyvideo_FastVideo_LoRA-fp8.safetensors', 'img2vid.safetensors', 'kxsr_walking_anim_v1-5.safetensors', 'lora12-000002_converted.safetensors', 'lora13-000004_converted.safetensors', 'low_noise_model.safetensors', 'ltx-2-19b-lora-camera-control-dolly-left.safetensors', 'ltxv-097-ic-lora-canny-control-comfyui.safetensors', 'ltxv-097-ic-lora-depth-control-comfyui.safetensors', 'ltxv-097-ic-lora-pose-control-comfyui.safetensors', 'ltxv-098-ic-lora-detailer-comfyui.safetensors', 'makima_hunyuan.safetensors', 'minimax_h3_fl2v_turbo_4step_v0.1_comfyui.safetensors', 'minimax_h3_fl2v_turbo_4step_v0.1_comfyui_alpha8-T8-convert.safetensors', 'minimax_h3_fl2v_turbo_4step_v0.1_comfyui_alpha8.safetensors', 'minimax_h3_turbo_4步加速_comfyui.safetensors', 'minimax_h3_turbo_4步加速ema_comfyui.safetensors', 'n_wan_1.3b_motion_helper.safetensors', 'oralv2_hunyuan_video_v2_e11_logsnr.safetensors', 'pcm_sd15_smallcfg_2step_converted.safetensors', 'reika_hunyuan_video_v4_e22.safetensors', 'skyreels-i2v-smooth-lora-test-00000350.safetensors', 'squish_18.safetensors', 'ttp_goyounjung.safetensors', 'wan2.1-1.3b-control-lora-tile-v0.2_comfy.safetensors', 'z-image-turbo-fix-speed.safetensors', '万物放气.safetensors', '人物飞翔.safetensors', '压扁480p_V20.safetensors', '变胖飞走.safetensors', '大摆锤200.safetensors', '奶louchu(1).safetensors', '打耳光720P.safetensors', '拿枪射击.safetensors', '断头.safetensors', '泼水BigSplashV01.safetensors', '混元视频_3D卡通蛇_混元视频3D卡通蛇.safetensors', '物体腐烂.safetensors', '男女秀肌肉18.safetensors', '羞羞的铁拳480p.safetensors', '脱下wan.safetensors']",
+          "widget": {
+            "name": "lora_name"
+          },
+          "link": null
+        },
+        {
+          "name": "strength_model",
+          "type": "FLOAT",
+          "widget": {
+            "name": "strength_model"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "MODEL",
+          "type": "MODEL",
+          "links": [
+            11
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "LoraLoaderModelOnly"
+      },
+      "widgets_values": [
+        "minimax_h3_turbo_4步加速ema_comfyui.safetensors",
+        1.0
+      ]
+    },
+    {
+      "id": 3,
+      "type": "CLIPLoader",
+      "title": "Reuse H3 Qwen3-VL text encoder",
+      "pos": [
+        0,
+        300
+      ],
+      "size": [
+        390,
+        212
+      ],
+      "flags": {},
+      "order": 2,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip_name",
+          "type": "['Long-ViT-L-14-GmP-SAE-TE-only.safetensors', 'ViT-L-14-GmP-SAE-TE-only.safetensors', 'clip-vit-large-patch14\\\\model.safetensors', 'clip_l.safetensors', 'gemma_3_12B_it.safetensors', 'google-flan-t5-large\\\\model.safetensors', 'llava_llama3_fp8_scaled.safetensors', 'models_t5_umt5-xxl-enc-bf16.pth', 'nsfw_wan_umt5-xxl_fp8_scaled.safetensors', 'oldt5_xxl_fp8_e4m3fn_scaled.safetensors', 'open-clip-xlm-roberta-large-vit-huge-14_fp16.safetensors', 'open-clip-xlm-roberta-large-vit-huge-14_visual_fp32.safetensors', 'qwen3.5_2b_bf16.safetensors', 'qwen3vl_32b_minimax_h3_int8_convrot.safetensors', 'qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors', 'qwen3vl_8b_fp8_scaled.safetensors', 'qwen_0.6b_ace15.safetensors', 'qwen_1.7b_ace15.safetensors', 'qwen_3_06b_base.safetensors', 'qwen_3_4b.safetensors', 't5\\\\google_t5-v1_1-xxl_encoderonly-fp8_e4m3fn.safetensors', 't5gemma_b_b_ul2.safetensors', 't5xxl_fp16.safetensors', 't5xxl_fp8_e4m3fn.safetensors', 'umt5-xxl-enc-bf16.safetensors', 'umt5_xxl_fp16.safetensors', 'umt5_xxl_fp8_e4m3fn_scaled.safetensors']",
+          "widget": {
+            "name": "clip_name"
+          },
+          "link": null
+        },
+        {
+          "name": "type",
+          "type": "['stable_diffusion', 'stable_cascade', 'sd3', 'stable_audio', 'mochi', 'ltxv', 'pixart', 'cosmos', 'lumina2', 'wan', 'hidream', 'chroma', 'ace', 'omnigen2', 'qwen_image', 'hunyuan_image', 'flux2', 'ovis', 'longcat_image', 'cogvideox', 'lens', 'pixeldit', 'ideogram4', 'boogu', 'krea2', 'joyimage', 'mage', 'minimax']",
+          "widget": {
+            "name": "type"
+          },
+          "link": null
+        },
+        {
+          "name": "device",
+          "type": "['default', 'cpu']",
+          "widget": {
+            "name": "device"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "CLIP",
+          "type": "CLIP",
+          "links": [
+            3
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "CLIPLoader"
+      },
+      "widgets_values": [
+        "qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors",
+        "minimax",
+        "default"
+      ]
+    },
+    {
+      "id": 4,
+      "type": "VAELoader",
+      "title": "Load H3 video VAE",
+      "pos": [
+        0,
+        600
+      ],
+      "size": [
+        390,
+        124
+      ],
+      "flags": {},
+      "order": 3,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "vae_name",
+          "type": "['Wan2.1_VAE.pth', 'Wan2_1_VAE_bf16.safetensors', 'WanVideo_MTV_Crafter_4DMoT_VQVAE_fp32.safetensors', 'ace_1.5_vae.safetensors', 'ae.safetensors', 'cog-vae-mz.safetensors', 'comfy-wan_2.1_vae.safetensors', 'cosmos_cv8x8x8_1.0.safetensors', 'diffusion_pytorch_model.safetensors', 'flux1_vae_bf16.safetensors', 'hunyuan_video_vae_bf16.safetensors', 'hunyuan_video_vae_fp32.safetensors', 'minimax_h3_audio_vae_fp32.safetensors', 'minimax_h3_video_vae_fp16.safetensors', 'mochi\\\\mochi_preview_vae_bf16.safetensors', 'mochi\\\\mochi_preview_vae_decoder_bf16.safetensors', 'mochi_preview_vae_decoder_bf16.safetensors', 'mochi_preview_vae_encoder_bf16_.safetensors', 'mochi_preview_vae_encoder_fp32.safetensors', 'oldt5_xxl_fp8_e4m3fn_scaled.safetensors', 'pyramid_flow_vae_bf16.safetensors', 'pyramid_flow_vae_fp32.safetensors', 'qwen_image_vae.safetensors', 'sdxl_vae_fp16fix.safetensors', 'vae-ft-mse-840000-ema-pruned.safetensors', 'vae-i2v-hunyuan.pt', 'wan2.2_vae.safetensors', 'pixel_space']",
+          "widget": {
+            "name": "vae_name"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            4,
+            21
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": [
+        "minimax_h3_video_vae_fp16.safetensors"
+      ]
+    },
+    {
+      "id": 5,
+      "type": "VAELoader",
+      "title": "Load H3 audio VAE",
+      "pos": [
+        0,
+        900
+      ],
+      "size": [
+        390,
+        124
+      ],
+      "flags": {},
+      "order": 4,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "vae_name",
+          "type": "['Wan2.1_VAE.pth', 'Wan2_1_VAE_bf16.safetensors', 'WanVideo_MTV_Crafter_4DMoT_VQVAE_fp32.safetensors', 'ace_1.5_vae.safetensors', 'ae.safetensors', 'cog-vae-mz.safetensors', 'comfy-wan_2.1_vae.safetensors', 'cosmos_cv8x8x8_1.0.safetensors', 'diffusion_pytorch_model.safetensors', 'flux1_vae_bf16.safetensors', 'hunyuan_video_vae_bf16.safetensors', 'hunyuan_video_vae_fp32.safetensors', 'minimax_h3_audio_vae_fp32.safetensors', 'minimax_h3_video_vae_fp16.safetensors', 'mochi\\\\mochi_preview_vae_bf16.safetensors', 'mochi\\\\mochi_preview_vae_decoder_bf16.safetensors', 'mochi_preview_vae_decoder_bf16.safetensors', 'mochi_preview_vae_encoder_bf16_.safetensors', 'mochi_preview_vae_encoder_fp32.safetensors', 'oldt5_xxl_fp8_e4m3fn_scaled.safetensors', 'pyramid_flow_vae_bf16.safetensors', 'pyramid_flow_vae_fp32.safetensors', 'qwen_image_vae.safetensors', 'sdxl_vae_fp16fix.safetensors', 'vae-ft-mse-840000-ema-pruned.safetensors', 'vae-i2v-hunyuan.pt', 'wan2.2_vae.safetensors', 'pixel_space']",
+          "widget": {
+            "name": "vae_name"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "VAE",
+          "type": "VAE",
+          "links": [
+            5,
+            9,
+            22
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "VAELoader"
+      },
+      "widgets_values": [
+        "minimax_h3_audio_vae_fp32.safetensors"
+      ]
+    },
+    {
+      "id": 6,
+      "type": "LoadAudio",
+      "title": "Independent music + ambience + SFX bed; it must contain no dialogue",
+      "pos": [
+        0,
+        1200
+      ],
+      "size": [
+        390,
+        124
+      ],
+      "flags": {},
+      "order": 5,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "COMBO",
+          "widget": {
+            "name": "audio"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "AUDIO",
+          "type": "AUDIO",
+          "links": [
+            2
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "LoadAudio"
+      },
+      "widgets_values": [
+        "replace_with_full_duration_background_bed.wav"
+      ]
+    },
+    {
+      "id": 7,
+      "type": "MiniMaxH3AudioWindowT8",
+      "title": "Normalize bed to a 124-frame H3 window",
+      "pos": [
+        440,
+        300
+      ],
+      "size": [
+        390,
+        326
+      ],
+      "flags": {},
+      "order": 6,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 2
+        },
+        {
+          "name": "scene_start_seconds",
+          "type": "FLOAT",
+          "widget": {
+            "name": "scene_start_seconds"
+          },
+          "link": null
+        },
+        {
+          "name": "scene_duration_seconds",
+          "type": "FLOAT",
+          "widget": {
+            "name": "scene_duration_seconds"
+          },
+          "link": null
+        },
+        {
+          "name": "warmup_seconds",
+          "type": "FLOAT",
+          "widget": {
+            "name": "warmup_seconds"
+          },
+          "link": null
+        },
+        {
+          "name": "cooldown_seconds",
+          "type": "FLOAT",
+          "widget": {
+            "name": "cooldown_seconds"
+          },
+          "link": null
+        },
+        {
+          "name": "ensure_minimum_context",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "ensure_minimum_context"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "context_audio",
+          "type": "AUDIO",
+          "links": [
+            8
+          ]
+        },
+        {
+          "name": "length",
+          "type": "INT",
+          "links": [
+            6
+          ]
+        },
+        {
+          "name": "final_trim_start_seconds",
+          "type": "FLOAT",
+          "links": null
+        },
+        {
+          "name": "final_duration_seconds",
+          "type": "FLOAT",
+          "links": null
+        },
+        {
+          "name": "prompt_timing_note",
+          "type": "STRING",
+          "links": null
+        },
+        {
+          "name": "report_json",
+          "type": "STRING",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "minimax-h3-audio-T8",
+        "Node name for S&R": "MiniMaxH3AudioWindowT8"
+      },
+      "widgets_values": [
+        0.0,
+        5.1666666667,
+        0.0,
+        0.0,
+        true
+      ]
+    },
+    {
+      "id": 8,
+      "type": "MiniMaxH3AudioConditioningT8",
+      "title": "Generate dialogue only in the editable head interval",
+      "pos": [
+        880,
+        0
+      ],
+      "size": [
+        390,
+        668
+      ],
+      "flags": {},
+      "order": 7,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "clip",
+          "type": "CLIP",
+          "link": 3
+        },
+        {
+          "name": "video_vae",
+          "type": "VAE",
+          "link": 4
+        },
+        {
+          "name": "audio_vae",
+          "type": "VAE",
+          "link": 5
+        },
+        {
+          "name": "prompt",
+          "type": "STRING",
+          "widget": {
+            "name": "prompt"
+          },
+          "link": null
+        },
+        {
+          "name": "width",
+          "type": "INT",
+          "widget": {
+            "name": "width"
+          },
+          "link": null
+        },
+        {
+          "name": "height",
+          "type": "INT",
+          "widget": {
+            "name": "height"
+          },
+          "link": null
+        },
+        {
+          "name": "length",
+          "type": "INT",
+          "link": 6
+        },
+        {
+          "name": "task_type",
+          "type": "COMBO",
+          "widget": {
+            "name": "task_type"
+          },
+          "link": null
+        },
+        {
+          "name": "audio_mode",
+          "type": "COMBO",
+          "widget": {
+            "name": "audio_mode"
+          },
+          "link": null
+        },
+        {
+          "name": "audio_denoise_strength",
+          "type": "FLOAT",
+          "widget": {
+            "name": "audio_denoise_strength"
+          },
+          "link": null
+        },
+        {
+          "name": "add_source_as_reference",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "add_source_as_reference"
+          },
+          "link": null
+        },
+        {
+          "name": "prompt_primary_audio_ordinal",
+          "type": "INT",
+          "widget": {
+            "name": "prompt_primary_audio_ordinal"
+          },
+          "link": null
+        },
+        {
+          "name": "strict_prompt_tags",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "strict_prompt_tags"
+          },
+          "link": null
+        },
+        {
+          "name": "ref_image_size",
+          "type": "COMBO",
+          "widget": {
+            "name": "ref_image_size"
+          },
+          "link": null
+        },
+        {
+          "name": "reference_video_policy",
+          "type": "COMBO",
+          "widget": {
+            "name": "reference_video_policy"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "positive",
+          "type": "CONDITIONING",
+          "links": [
+            14
+          ]
+        },
+        {
+          "name": "av_latent",
+          "type": "LATENT",
+          "links": [
+            7
+          ]
+        },
+        {
+          "name": "mux_audio",
+          "type": "AUDIO",
+          "links": null
+        },
+        {
+          "name": "conditioned_prompt",
+          "type": "STRING",
+          "links": null
+        },
+        {
+          "name": "media_map_json",
+          "type": "STRING",
+          "links": null
+        },
+        {
+          "name": "report",
+          "type": "STRING",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "minimax-h3-audio-T8",
+        "Node name for S&R": "MiniMaxH3AudioConditioningT8"
+      },
+      "widgets_values": [
+        "A quiet cinematic room. A person says exactly and only <d>The light is on.</d> After the final word the person stays silent and closes their mouth. Soft music, room ambience, and subtle sound effects continue naturally to the end.",
+        736,
+        416,
+        "T2VA",
+        "native",
+        1.0,
+        false,
+        0,
+        true,
+        "match",
+        "official_2_to_15s"
+      ]
+    },
+    {
+      "id": 9,
+      "type": "PrimitiveFloat",
+      "title": "Verified/planned dialogue end; latent lock is ceil-quantized to 40Hz",
+      "pos": [
+        0,
+        1500
+      ],
+      "size": [
+        390,
+        124
+      ],
+      "flags": {},
+      "order": 8,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "value",
+          "type": "FLOAT",
+          "widget": {
+            "name": "value"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "FLOAT",
+          "type": "FLOAT",
+          "links": [
+            10
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "PrimitiveFloat"
+      },
+      "widgets_values": [
+        2.0
+      ]
+    },
+    {
+      "id": 10,
+      "type": "MiniMaxH3TimedAudioBedLockT8",
+      "title": "Two-pass lock; normal 124F audio VAE encoding needs one reported pad step",
+      "pos": [
+        1320,
+        0
+      ],
+      "size": [
+        390,
+        360
+      ],
+      "flags": {},
+      "order": 9,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "av_latent",
+          "type": "LATENT",
+          "link": 7
+        },
+        {
+          "name": "background_audio",
+          "type": "AUDIO",
+          "link": 8
+        },
+        {
+          "name": "audio_vae",
+          "type": "VAE",
+          "link": 9
+        },
+        {
+          "name": "tail_lock_start_seconds",
+          "type": "FLOAT",
+          "link": 10
+        },
+        {
+          "name": "head_denoise_strength",
+          "type": "FLOAT",
+          "widget": {
+            "name": "head_denoise_strength"
+          },
+          "link": null
+        },
+        {
+          "name": "tail_denoise_strength",
+          "type": "FLOAT",
+          "widget": {
+            "name": "tail_denoise_strength"
+          },
+          "link": null
+        },
+        {
+          "name": "transition_seconds",
+          "type": "FLOAT",
+          "widget": {
+            "name": "transition_seconds"
+          },
+          "link": null
+        },
+        {
+          "name": "audio_latent_fit_policy",
+          "type": "COMBO",
+          "widget": {
+            "name": "audio_latent_fit_policy"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "av_latent",
+          "type": "LATENT",
+          "links": [
+            12,
+            19
+          ]
+        },
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "links": null
+        },
+        {
+          "name": "report_json",
+          "type": "STRING",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "minimax-h3-audio-T8",
+        "Node name for S&R": "MiniMaxH3TimedAudioBedLockT8"
+      },
+      "widgets_values": [
+        1.0,
+        0.0,
+        0.0,
+        "fit_reported"
+      ]
+    },
+    {
+      "id": 11,
+      "type": "MiniMaxH3DualClockSamplerT8",
+      "title": "Existing stable 4V/4A dual-clock defaults",
+      "pos": [
+        1760,
+        0
+      ],
+      "size": [
+        390,
+        352
+      ],
+      "flags": {},
+      "order": 10,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 11
+        },
+        {
+          "name": "av_latent",
+          "type": "LATENT",
+          "link": 12
+        },
+        {
+          "name": "steps",
+          "type": "INT",
+          "widget": {
+            "name": "steps"
+          },
+          "link": null
+        },
+        {
+          "name": "shift_video",
+          "type": "FLOAT",
+          "widget": {
+            "name": "shift_video"
+          },
+          "link": null
+        },
+        {
+          "name": "shift_audio",
+          "type": "FLOAT",
+          "widget": {
+            "name": "shift_audio"
+          },
+          "link": null
+        },
+        {
+          "name": "sampler_name",
+          "type": "COMBO",
+          "widget": {
+            "name": "sampler_name"
+          },
+          "link": null
+        },
+        {
+          "name": "scheduler",
+          "type": "COMBO",
+          "widget": {
+            "name": "scheduler"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "links": [
+            13
+          ]
+        },
+        {
+          "name": "sampler",
+          "type": "SAMPLER",
+          "links": [
+            17
+          ]
+        },
+        {
+          "name": "sigmas",
+          "type": "SIGMAS",
+          "links": [
+            18
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "minimax-h3-audio-T8",
+        "Node name for S&R": "MiniMaxH3DualClockSamplerT8"
+      },
+      "widgets_values": [
+        4,
+        12.0,
+        3.0,
+        "dual_clock_euler",
+        "native_flow"
+      ]
+    },
+    {
+      "id": 12,
+      "type": "RandomNoise",
+      "title": null,
+      "pos": [
+        0,
+        1800
+      ],
+      "size": [
+        390,
+        142
+      ],
+      "flags": {},
+      "order": 11,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "noise_seed",
+          "type": "INT",
+          "widget": {
+            "name": "noise_seed"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "NOISE",
+          "type": "NOISE",
+          "links": [
+            15
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "RandomNoise"
+      },
+      "widgets_values": [
+        2608105101,
+        "fixed"
+      ]
+    },
+    {
+      "id": 13,
+      "type": "BasicGuider",
+      "title": "Basic Guider",
+      "pos": [
+        2200,
+        0
+      ],
+      "size": [
+        390,
+        132
+      ],
+      "flags": {},
+      "order": 12,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "model",
+          "type": "MODEL",
+          "link": 13
+        },
+        {
+          "name": "conditioning",
+          "type": "CONDITIONING",
+          "link": 14
+        }
+      ],
+      "outputs": [
+        {
+          "name": "GUIDER",
+          "type": "GUIDER",
+          "links": [
+            16
+          ]
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "BasicGuider"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 14,
+      "type": "SamplerCustomAdvanced",
+      "title": null,
+      "pos": [
+        2640,
+        0
+      ],
+      "size": [
+        390,
+        210
+      ],
+      "flags": {},
+      "order": 13,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "noise",
+          "type": "NOISE",
+          "link": 15
+        },
+        {
+          "name": "guider",
+          "type": "GUIDER",
+          "link": 16
+        },
+        {
+          "name": "sampler",
+          "type": "SAMPLER",
+          "link": 17
+        },
+        {
+          "name": "sigmas",
+          "type": "SIGMAS",
+          "link": 18
+        },
+        {
+          "name": "latent_image",
+          "type": "LATENT",
+          "link": 19
+        }
+      ],
+      "outputs": [
+        {
+          "name": "output",
+          "type": "LATENT",
+          "links": [
+            20
+          ]
+        },
+        {
+          "name": "denoised_output",
+          "type": "LATENT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "SamplerCustomAdvanced"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 15,
+      "type": "MiniMaxH3AVDecodeT8",
+      "title": "MiniMax H3 AV Decode (T8)",
+      "pos": [
+        3080,
+        0
+      ],
+      "size": [
+        390,
+        158
+      ],
+      "flags": {},
+      "order": 14,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "av_latent",
+          "type": "LATENT",
+          "link": 20
+        },
+        {
+          "name": "video_vae",
+          "type": "VAE",
+          "link": 21
+        },
+        {
+          "name": "audio_vae",
+          "type": "VAE",
+          "link": 22
+        }
+      ],
+      "outputs": [
+        {
+          "name": "frames",
+          "type": "IMAGE",
+          "links": [
+            23
+          ]
+        },
+        {
+          "name": "generated_audio",
+          "type": "AUDIO",
+          "links": [
+            24
+          ]
+        },
+        {
+          "name": "video_latent",
+          "type": "LATENT",
+          "links": null
+        },
+        {
+          "name": "audio_latent",
+          "type": "LATENT",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "minimax-h3-audio-T8",
+        "Node name for S&R": "MiniMaxH3AVDecodeT8"
+      },
+      "widgets_values": []
+    },
+    {
+      "id": 16,
+      "type": "VHS_VideoCombine",
+      "title": "Save full AV result; do not trim the master at the dialogue end",
+      "pos": [
+        3520,
+        0
+      ],
+      "size": [
+        390,
+        572
+      ],
+      "flags": {},
+      "order": 15,
+      "mode": 0,
+      "inputs": [
+        {
+          "name": "images",
+          "type": "IMAGE",
+          "link": 23
+        },
+        {
+          "name": "audio",
+          "type": "AUDIO",
+          "link": 24
+        },
+        {
+          "name": "frame_rate",
+          "type": "FLOAT",
+          "widget": {
+            "name": "frame_rate"
+          },
+          "link": null
+        },
+        {
+          "name": "loop_count",
+          "type": "INT",
+          "widget": {
+            "name": "loop_count"
+          },
+          "link": null
+        },
+        {
+          "name": "filename_prefix",
+          "type": "STRING",
+          "widget": {
+            "name": "filename_prefix"
+          },
+          "link": null
+        },
+        {
+          "name": "format",
+          "type": "['image/gif', 'image/webp', 'video/16bit-png', 'video/8bit-png', 'video/av1-webm', 'video/ffmpeg-gif', 'video/ffv1-mkv', 'video/h264-mp4', 'video/h265-mp4', 'video/nvenc_av1-mp4', 'video/nvenc_h264-mp4', 'video/nvenc_hevc-mp4', 'video/ProRes', 'video/webm']",
+          "widget": {
+            "name": "format"
+          },
+          "link": null
+        },
+        {
+          "name": "pix_fmt",
+          "type": "*",
+          "widget": {
+            "name": "pix_fmt"
+          },
+          "link": null
+        },
+        {
+          "name": "crf",
+          "type": "*",
+          "widget": {
+            "name": "crf"
+          },
+          "link": null
+        },
+        {
+          "name": "save_metadata",
+          "type": "*",
+          "widget": {
+            "name": "save_metadata"
+          },
+          "link": null
+        },
+        {
+          "name": "trim_to_audio",
+          "type": "*",
+          "widget": {
+            "name": "trim_to_audio"
+          },
+          "link": null
+        },
+        {
+          "name": "pingpong",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "pingpong"
+          },
+          "link": null
+        },
+        {
+          "name": "save_output",
+          "type": "BOOLEAN",
+          "widget": {
+            "name": "save_output"
+          },
+          "link": null
+        }
+      ],
+      "outputs": [
+        {
+          "name": "Filenames",
+          "type": "VHS_FILENAMES",
+          "links": null
+        }
+      ],
+      "properties": {
+        "cnr_id": "comfy-core",
+        "Node name for S&R": "VHS_VideoCombine"
+      },
+      "widgets_values": [
+        24,
+        0,
+        "MiniMaxH3_T8_DialogueSafe/timed_background_bed_lock",
+        "video/h264-mp4",
+        "yuv420p",
+        19,
+        true,
+        false,
+        false,
+        true
+      ]
+    }
+  ],
+  "links": [
+    [
+      1,
+      1,
+      0,
+      2,
+      0,
+      "MODEL"
+    ],
+    [
+      2,
+      6,
+      0,
+      7,
+      0,
+      "AUDIO"
+    ],
+    [
+      3,
+      3,
+      0,
+      8,
+      0,
+      "CLIP"
+    ],
+    [
+      4,
+      4,
+      0,
+      8,
+      1,
+      "VAE"
+    ],
+    [
+      5,
+      5,
+      0,
+      8,
+      2,
+      "VAE"
+    ],
+    [
+      6,
+      7,
+      1,
+      8,
+      6,
+      "INT"
+    ],
+    [
+      7,
+      8,
+      1,
+      10,
+      0,
+      "LATENT"
+    ],
+    [
+      8,
+      7,
+      0,
+      10,
+      1,
+      "AUDIO"
+    ],
+    [
+      9,
+      5,
+      0,
+      10,
+      2,
+      "VAE"
+    ],
+    [
+      10,
+      9,
+      0,
+      10,
+      3,
+      "FLOAT"
+    ],
+    [
+      11,
+      2,
+      0,
+      11,
+      0,
+      "MODEL"
+    ],
+    [
+      12,
+      10,
+      0,
+      11,
+      1,
+      "LATENT"
+    ],
+    [
+      13,
+      11,
+      0,
+      13,
+      0,
+      "MODEL"
+    ],
+    [
+      14,
+      8,
+      0,
+      13,
+      1,
+      "CONDITIONING"
+    ],
+    [
+      15,
+      12,
+      0,
+      14,
+      0,
+      "NOISE"
+    ],
+    [
+      16,
+      13,
+      0,
+      14,
+      1,
+      "GUIDER"
+    ],
+    [
+      17,
+      11,
+      1,
+      14,
+      2,
+      "SAMPLER"
+    ],
+    [
+      18,
+      11,
+      2,
+      14,
+      3,
+      "SIGMAS"
+    ],
+    [
+      19,
+      10,
+      0,
+      14,
+      4,
+      "LATENT"
+    ],
+    [
+      20,
+      14,
+      0,
+      15,
+      0,
+      "LATENT"
+    ],
+    [
+      21,
+      4,
+      0,
+      15,
+      1,
+      "VAE"
+    ],
+    [
+      22,
+      5,
+      0,
+      15,
+      2,
+      "VAE"
+    ],
+    [
+      23,
+      15,
+      0,
+      16,
+      0,
+      "IMAGE"
+    ],
+    [
+      24,
+      15,
+      1,
+      16,
+      1,
+      "AUDIO"
+    ]
+  ],
+  "groups": [],
+  "config": {},
+  "extra": {
+    "ds": {
+      "scale": 0.75,
+      "offset": [
+        120,
+        120
+      ]
+    },
+    "workflow_title": "MiniMax H3 Timed Background Bed Lock EXP"
+  },
+  "version": 0.4
+}

--- a/features.json
+++ b/features.json
@@ -67,8 +67,68 @@
     "MiniMaxH3JointDialogueConditioningT8",
     "MiniMaxH3SourceMediaWindowT8",
     "MiniMaxH3SourceAVPrepareT8",
-    "MiniMaxH3AVLatentSeparateT8"
+    "MiniMaxH3AVLatentSeparateT8",
+    "MiniMaxH3DialogueBoundaryAnalyzerT8",
+    "MiniMaxH3DialogueSafeMasterT8",
+    "MiniMaxH3TimedAudioBedLockT8"
   ],
+  "experimental_dialogue_safe_audio": {
+    "category": "T8/MiniMax H3/Speech/Experimental",
+    "nodes": [
+      "MiniMaxH3DialogueBoundaryAnalyzerT8",
+      "MiniMaxH3DialogueSafeMasterT8",
+      "MiniMaxH3TimedAudioBedLockT8"
+    ],
+    "problem": "H3 may generate extra unrequested speech after the requested line while the same stereo master still contains wanted music, ambience, and sound effects; trimming the whole master at the speech boundary destroys those wanted sounds.",
+    "boundary_analyzer": {
+      "behavior": "local CPU faster-whisper reports a boundary only when exactly one contiguous exact normalized target sequence is present",
+      "ambiguous_repetition": "rejected rather than selecting the first or last occurrence",
+      "audio_mutation": false,
+      "tail_energy": "reported only as signal activity, never classified as speech"
+    },
+    "safe_master": {
+      "required_inputs": "an already verified independent speech stem plus optional independent full-duration music, ambience, and SFX stems",
+      "duration": "sample-exact at 32kHz, 44.1kHz, or 48kHz",
+      "default_fit_policy": "strict; no stem is silently looped, padded, or trimmed",
+      "guarantee": "the final master is not truncated at the speech end"
+    },
+    "timed_background_bed_lock": {
+      "workflow": "two-pass H3 helper using an independent full-duration background bed",
+      "boundary": "ceil-quantized to the 40Hz H3 audio latent grid so locking never begins earlier than requested",
+      "default_tail_denoise": 0.0,
+      "default_transition_seconds": 0.0,
+      "default_fit_policy": "strict",
+      "mask_contract": "video stream remains unchanged; an existing audio noise mask is a cap, so the node does not increase generation freedom",
+      "real_four_step_probe": {
+        "environment": "RTX 4060 Ti 16GiB; ComfyUI 0.31.0 at cbbc9dab1; DynamicVRAM",
+        "model": "FL2VA pruned INT8; Qwen3-VL NVFP4; H3 Audio VAE",
+        "canvas_and_window": "256x256; 124 frames; 4-step stable dual clock",
+        "audio_fit": "Audio Window encoded to T=206 versus AV target T=207; strict rejected and fit_reported explicitly zero-padded one latent step",
+        "boundary": "2.0 seconds / audio latent step 80",
+        "editable_head_mean_abs_change": 0.5022301078,
+        "locked_tail_max_abs_change": 0.0000002384185791,
+        "locked_tail_allclose_atol_1e_6": true,
+        "decoded_boundary_observation": "H3 Audio VAE temporal context produced material difference for roughly the first 0.3 seconds after the latent boundary; later windows were near-equal but not bit-identical"
+      },
+      "status": "real four-step H3 sampling validated the locked latent endpoint within 1e-6; decoded perceptual quality and seamlessness remain unvalidated"
+    },
+    "api_examples": [
+      "examples/dialogue_safe_master_api.json",
+      "examples/dialogue_timed_bed_lock_api.json"
+    ],
+    "frontend_workflows": [
+      "examples/workflows/H3_Dialogue_Safe_Master_EXP.json",
+      "examples/workflows/H3_Dialogue_Timed_Background_Bed_Lock_EXP.json"
+    ],
+    "scientific_limits": [
+      "No source separation is performed; an already mixed H3 master cannot be safely repaired by these nodes alone.",
+      "Music-vocal separators are not assumed to be dialogue removers and may remove intentional singing or damage music/SFX.",
+      "A 40Hz latent boundary is not a sample-exact decoded speech endpoint because the audio VAE has temporal context.",
+      "Prompt directions and latent locking do not guarantee that the visible character stops mouth motion.",
+      "No 16GiB memory_safe claim is made."
+    ],
+    "compatibility": "all prior 51 node IDs, ordering, defaults, and execution paths are unchanged; three opt-in EXP nodes are appended"
+  },
   "sampling": {
     "algorithm": "selectable sampler and scheduler with a backward-compatible dual-clock default",
     "default_steps": 4,

--- a/meta.json
+++ b/meta.json
@@ -1,6 +1,6 @@
 {
   "name": "minimax-h3-audio-T8",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "category": "T8/MiniMax H3/Audio",
   "license": "GPL-3.0-or-later",
   "validated_on": "2026-08-10",

--- a/nodes.py
+++ b/nodes.py
@@ -4,6 +4,7 @@ from comfy_api.latest import ComfyExtension, io
 
 from .audio_ops import decode_av_latent, inject_audio_latent, mix_audio, trim_av_output
 from .conditioning import build_conditioning
+from .nodes_dialogue_audio_exp import DIALOGUE_AUDIO_NODE_CLASSES
 from .nodes_multirate_exp import MiniMaxH3MultiRateSamplerEXPT8
 from .nodes_long_video_exp import (
     MiniMaxH3LongVideoConditioningT8,
@@ -385,7 +386,8 @@ class MiniMaxH3AudioT8Extension(ComfyExtension):
                 *SPEECH_NODE_CLASSES[:10],
                 MiniMaxH3VisualReferenceStrengthEXPT8,
                 *SPEECH_NODE_CLASSES[10:],
-                *SOURCE_AV_NODE_CLASSES]
+                *SOURCE_AV_NODE_CLASSES,
+                *DIALOGUE_AUDIO_NODE_CLASSES]
 
 
 def comfy_entrypoint():

--- a/nodes_dialogue_audio_exp.py
+++ b/nodes_dialogue_audio_exp.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+from comfy_api.latest import io
+
+from .dialogue_audio import (
+    BED_FIT_POLICIES,
+    SFX_FIT_POLICIES,
+    build_dialogue_safe_master,
+)
+from .speech import SPEECH_CATEGORY
+from .speech_verification import ASR_LANGUAGE_CODES, analyze_dialogue_boundary
+from .timed_audio_latent import (
+    AUDIO_LATENT_FIT_POLICIES,
+    build_timed_audio_bed_lock,
+)
+
+
+class MiniMaxH3DialogueBoundaryAnalyzerT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3DialogueBoundaryAnalyzerT8",
+            display_name="MiniMax H3 Dialogue Boundary Analyzer / 对白边界分析 (EXP/T8)",
+            description=(
+                "Runs local CPU faster-whisper and reports a boundary only when exactly one "
+                "contiguous exact target-text sequence is found. It never edits audio and does "
+                "not infer that tail energy is speech."
+            ),
+            category=SPEECH_CATEGORY,
+            is_experimental=True,
+            inputs=[
+                io.Audio.Input("audio"),
+                io.String.Input("expected_text", multiline=True, force_input=True),
+                io.String.Input(
+                    "asr_model_directory",
+                    default="",
+                    tooltip=(
+                        "Absolute faster-whisper CTranslate2 directory, or a folder under "
+                        "ComfyUI/models/TTS. No model is downloaded automatically."
+                    ),
+                ),
+                io.Combo.Input(
+                    "language",
+                    options=list(ASR_LANGUAGE_CODES),
+                    default="auto",
+                ),
+                io.Int.Input("beam_size", default=5, min=1, max=20, advanced=True),
+                io.Int.Input("cpu_threads", default=8, min=1, max=64, advanced=True),
+                io.Boolean.Input("unload_after_analyze", default=True),
+                io.Float.Input(
+                    "tail_activity_threshold_dbfs",
+                    default=-45.0,
+                    min=-120.0,
+                    max=0.0,
+                    step=0.5,
+                    advanced=True,
+                    tooltip=(
+                        "Only reports post-target signal activity. This is not a VAD or a "
+                        "speech/non-speech decision."
+                    ),
+                ),
+            ],
+            outputs=[
+                io.String.Output("transcript"),
+                io.Boolean.Output("unique_target_found"),
+                io.Boolean.Output("clean_exact"),
+                io.Float.Output("speech_start_seconds"),
+                io.Float.Output("speech_end_seconds"),
+                io.Int.Output("extra_before_units"),
+                io.Int.Output("extra_after_units"),
+                io.String.Output("report_json"),
+            ],
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        audio,
+        expected_text,
+        asr_model_directory,
+        language,
+        beam_size,
+        cpu_threads,
+        unload_after_analyze,
+        tail_activity_threshold_dbfs,
+    ):
+        return io.NodeOutput(
+            *analyze_dialogue_boundary(
+                audio,
+                expected_text,
+                asr_model_directory,
+                language,
+                beam_size,
+                cpu_threads,
+                unload_after_analyze,
+                tail_activity_threshold_dbfs,
+            )
+        )
+
+
+class MiniMaxH3DialogueSafeMasterT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3DialogueSafeMasterT8",
+            display_name="MiniMax H3 Dialogue Safe Master / 对白安全混音 (EXP/T8)",
+            description=(
+                "Builds an exact-duration master from an already verified speech stem plus "
+                "independent music, ambience, and SFX stems. Speech is never silently trimmed, "
+                "and the master is never cut at the dialogue end. This is not source separation."
+            ),
+            category=SPEECH_CATEGORY,
+            is_experimental=True,
+            inputs=[
+                io.Audio.Input("speech_audio"),
+                io.Boolean.Input(
+                    "speech_accepted",
+                    default=False,
+                    force_input=True,
+                    tooltip=(
+                        "Connect accepted from Speech Verify after exact-target alignment. "
+                        "False is rejected; this mixer will not guess speech cleanliness."
+                    ),
+                ),
+                io.Float.Input(
+                    "target_duration_seconds",
+                    default=10.0,
+                    min=0.001,
+                    max=36000.0,
+                    step=0.001,
+                ),
+                io.Float.Input(
+                    "speech_start_seconds",
+                    default=0.0,
+                    min=0.0,
+                    max=36000.0,
+                    step=0.001,
+                ),
+                io.Combo.Input(
+                    "output_sample_rate",
+                    options=[32000, 44100, 48000],
+                    default=32000,
+                ),
+                io.Combo.Input(
+                    "music_fit_policy",
+                    options=list(BED_FIT_POLICIES),
+                    default="strict",
+                ),
+                io.Combo.Input(
+                    "ambience_fit_policy",
+                    options=list(BED_FIT_POLICIES),
+                    default="strict",
+                ),
+                io.Combo.Input(
+                    "sfx_fit_policy",
+                    options=list(SFX_FIT_POLICIES),
+                    default="strict",
+                    tooltip="SFX can be padded/trimmed explicitly but is never looped.",
+                ),
+                io.Float.Input(
+                    "loop_crossfade_seconds",
+                    default=0.25,
+                    min=0.0,
+                    max=5.0,
+                    step=0.01,
+                    advanced=True,
+                ),
+                io.Float.Input("speech_gain_db", default=0.0, min=-60.0, max=24.0, step=0.1),
+                io.Float.Input("music_gain_db", default=0.0, min=-60.0, max=24.0, step=0.1),
+                io.Float.Input("ambience_gain_db", default=0.0, min=-60.0, max=24.0, step=0.1),
+                io.Float.Input("sfx_gain_db", default=0.0, min=-60.0, max=24.0, step=0.1),
+                io.Float.Input(
+                    "duck_background",
+                    default=0.0,
+                    min=0.0,
+                    max=1.0,
+                    step=0.01,
+                    tooltip="Deterministically attenuates all background stems while speech is active.",
+                ),
+                io.Float.Input(
+                    "peak_limit_dbfs",
+                    default=-1.0,
+                    min=-24.0,
+                    max=0.0,
+                    step=0.1,
+                ),
+                io.Audio.Input("music_audio", optional=True),
+                io.Audio.Input("ambience_audio", optional=True),
+                io.Audio.Input("sfx_audio", optional=True),
+            ],
+            outputs=[
+                io.Audio.Output("master_audio"),
+                io.Audio.Output("speech_stem"),
+                io.Audio.Output("background_stem"),
+                io.String.Output("report_json"),
+            ],
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        speech_audio,
+        speech_accepted,
+        target_duration_seconds,
+        speech_start_seconds,
+        output_sample_rate,
+        music_fit_policy,
+        ambience_fit_policy,
+        sfx_fit_policy,
+        loop_crossfade_seconds,
+        speech_gain_db,
+        music_gain_db,
+        ambience_gain_db,
+        sfx_gain_db,
+        duck_background,
+        peak_limit_dbfs,
+        music_audio=None,
+        ambience_audio=None,
+        sfx_audio=None,
+    ):
+        return io.NodeOutput(
+            *build_dialogue_safe_master(
+                speech_audio,
+                speech_accepted,
+                target_duration_seconds,
+                speech_start_seconds,
+                output_sample_rate,
+                music_fit_policy,
+                ambience_fit_policy,
+                sfx_fit_policy,
+                loop_crossfade_seconds,
+                speech_gain_db,
+                music_gain_db,
+                ambience_gain_db,
+                sfx_gain_db,
+                duck_background,
+                peak_limit_dbfs,
+                music_audio,
+                ambience_audio,
+                sfx_audio,
+            )
+        )
+
+
+class MiniMaxH3TimedAudioBedLockT8(io.ComfyNode):
+    @classmethod
+    def define_schema(cls):
+        return io.Schema(
+            node_id="MiniMaxH3TimedAudioBedLockT8",
+            display_name=(
+                "MiniMax H3 Timed Background Bed Lock / 分时背景底轨锁定 (EXP/T8)"
+            ),
+            description=(
+                "Two-pass H3 helper: encodes an independent full-duration music/ambience/SFX "
+                "bed into the AV latent and locks its tail after an explicit dialogue boundary. "
+                "It preserves the video stream and does not separate speech from a mixed master."
+            ),
+            category=SPEECH_CATEGORY,
+            is_experimental=True,
+            inputs=[
+                io.Latent.Input("av_latent"),
+                io.Audio.Input("background_audio"),
+                io.Vae.Input("audio_vae"),
+                io.Float.Input(
+                    "tail_lock_start_seconds",
+                    default=5.0,
+                    min=0.0,
+                    max=3600.0,
+                    step=0.001,
+                    force_input=True,
+                    tooltip=(
+                        "Connect a verified speech_end_seconds or an explicit planned boundary. "
+                        "It is quantized upward to the H3 40Hz audio-latent grid."
+                    ),
+                ),
+                io.Float.Input(
+                    "head_denoise_strength",
+                    default=1.0,
+                    min=0.0,
+                    max=1.0,
+                    step=0.01,
+                ),
+                io.Float.Input(
+                    "tail_denoise_strength",
+                    default=0.0,
+                    min=0.0,
+                    max=1.0,
+                    step=0.01,
+                    tooltip="Use 0 to request an unchanged background-bed latent endpoint.",
+                ),
+                io.Float.Input(
+                    "transition_seconds",
+                    default=0.0,
+                    min=0.0,
+                    max=10.0,
+                    step=0.025,
+                    advanced=True,
+                    tooltip=(
+                        "Default 0 makes the lock boundary explicit. A nonzero transition delays "
+                        "the fully locked tail and is reported, not assumed perceptually safer."
+                    ),
+                ),
+                io.Combo.Input(
+                    "audio_latent_fit_policy",
+                    options=list(AUDIO_LATENT_FIT_POLICIES),
+                    default="strict",
+                    tooltip=(
+                        "Strict rejects a duration mismatch. fit_reported explicitly trims or "
+                        "zero-pads the encoded latent and records the action."
+                    ),
+                ),
+            ],
+            outputs=[
+                io.Latent.Output("av_latent"),
+                io.Latent.Output("audio_latent"),
+                io.String.Output("report_json"),
+            ],
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        av_latent,
+        background_audio,
+        audio_vae,
+        tail_lock_start_seconds,
+        head_denoise_strength,
+        tail_denoise_strength,
+        transition_seconds,
+        audio_latent_fit_policy,
+    ):
+        return io.NodeOutput(
+            *build_timed_audio_bed_lock(
+                av_latent,
+                background_audio,
+                audio_vae,
+                tail_lock_start_seconds,
+                head_denoise_strength,
+                tail_denoise_strength,
+                transition_seconds,
+                audio_latent_fit_policy,
+            )
+        )
+
+
+DIALOGUE_AUDIO_NODE_CLASSES = [
+    MiniMaxH3DialogueBoundaryAnalyzerT8,
+    MiniMaxH3DialogueSafeMasterT8,
+    MiniMaxH3TimedAudioBedLockT8,
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "minimax-h3-audio-t8"
-version = "1.11.0"
-description = "MiniMax H3 audio, source-video AV repaint preparation, guarded speech/long-form voice workflows, dual-clock sampling, resumable long-video orchestration, and Ref2VA editing nodes for ComfyUI"
+version = "1.12.0"
+description = "MiniMax H3 audio, dialogue-safe stem mastering and timed background-bed locking, source-video AV repaint preparation, guarded speech workflows, dual-clock sampling, resumable long-video orchestration, and Ref2VA editing nodes for ComfyUI"
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "GPL-3.0-or-later" }

--- a/speech_verification.py
+++ b/speech_verification.py
@@ -55,6 +55,16 @@ def normalized_asr_units(text: str) -> list[str]:
     return _UNIT_PATTERN.findall(str(text or "").lower().replace("’", "'"))
 
 
+def _word_unit_stream(words: list[dict]) -> tuple[list[str], list[int]]:
+    heard_units: list[str] = []
+    owners: list[int] = []
+    for word_index, word in enumerate(words):
+        units = normalized_asr_units(word.get("word", ""))
+        heard_units.extend(units)
+        owners.extend([word_index] * len(units))
+    return heard_units, owners
+
+
 def _levenshtein(expected: list[str], heard: list[str]) -> int:
     row = list(range(len(heard) + 1))
     for expected_index, expected_unit in enumerate(expected, 1):
@@ -102,26 +112,40 @@ def transcript_metrics(expected: str, heard: str) -> dict:
     }
 
 
-def exact_target_word_bounds(words: list[dict], expected: str) -> tuple[float, float] | None:
+def exact_target_word_spans(words: list[dict], expected: str) -> list[dict]:
     expected_units = normalized_asr_units(expected)
     if not expected_units:
         raise ValueError("expected_text cannot be empty")
-    heard_units: list[str] = []
-    owners: list[int] = []
-    for word_index, word in enumerate(words):
-        units = normalized_asr_units(word.get("word", ""))
-        heard_units.extend(units)
-        owners.extend([word_index] * len(units))
+    heard_units, owners = _word_unit_stream(words)
     if len(heard_units) < len(expected_units):
-        return None
+        return []
+    spans = []
     for start in range(len(heard_units) - len(expected_units) + 1):
         end = start + len(expected_units)
         if heard_units[start:end] != expected_units:
             continue
-        first = words[owners[start]]
-        last = words[owners[end - 1]]
-        return float(first["start"]), float(last["end"])
-    return None
+        first_word_index = owners[start]
+        last_word_index = owners[end - 1]
+        first = words[first_word_index]
+        last = words[last_word_index]
+        spans.append(
+            {
+                "start_seconds": float(first["start"]),
+                "end_seconds": float(last["end"]),
+                "start_unit_index": start,
+                "end_unit_index": end,
+                "start_word_index": first_word_index,
+                "end_word_index": last_word_index + 1,
+            }
+        )
+    return spans
+
+
+def exact_target_word_bounds(words: list[dict], expected: str) -> tuple[float, float] | None:
+    spans = exact_target_word_spans(words, expected)
+    if not spans:
+        return None
+    return spans[0]["start_seconds"], spans[0]["end_seconds"]
 
 
 def _candidate_asr_roots() -> list[Path]:
@@ -316,6 +340,158 @@ def _transcribe(
         "duration_seconds": float(info.duration),
         "words": words,
     }
+
+
+def analyze_dialogue_boundary(
+    audio: Mapping,
+    expected_text: str,
+    asr_model_directory: str,
+    language: str = "auto",
+    beam_size: int = 5,
+    cpu_threads: int = 8,
+    unload_after_analyze: bool = True,
+    tail_activity_threshold_dbfs: float = -45.0,
+):
+    waveform, sample_rate = validate_audio(audio, "dialogue_mix")
+    expected_text = str(expected_text or "").strip()
+    if not expected_text:
+        raise ValueError("expected_text cannot be empty")
+    if language not in ASR_LANGUAGE_CODES:
+        raise ValueError(f"unsupported ASR language: {language}")
+    if not 1 <= int(beam_size) <= 20:
+        raise ValueError("beam_size must be between 1 and 20")
+    if not 1 <= int(cpu_threads) <= 64:
+        raise ValueError("cpu_threads must be between 1 and 64")
+    if not -120.0 <= float(tail_activity_threshold_dbfs) <= 0.0:
+        raise ValueError("tail_activity_threshold_dbfs must be between -120 and 0")
+
+    model_path = resolve_asr_model_directory(asr_model_directory)
+    with _ASR_LOCK:
+        model, reused = _load_asr_model(model_path, int(cpu_threads))
+        released = False
+        try:
+            result = _transcribe(model, audio, language, int(beam_size))
+        finally:
+            if unload_after_analyze:
+                released = _release_asr_model()
+
+    words = result["words"]
+    heard_units, _owners = _word_unit_stream(words)
+    spans = exact_target_word_spans(words, expected_text)
+    unique_target_found = len(spans) == 1
+    start_seconds = 0.0
+    end_seconds = 0.0
+    before_units: list[str] = []
+    after_units: list[str] = []
+    tail_signal = {
+        "measured": False,
+        "warning": "No unique exact ASR target boundary was available.",
+    }
+    if unique_target_found:
+        span = spans[0]
+        start_seconds = span["start_seconds"]
+        end_seconds = span["end_seconds"]
+        before_units = heard_units[: span["start_unit_index"]]
+        after_units = heard_units[span["end_unit_index"] :]
+        end_sample = min(waveform.shape[-1], round(end_seconds * sample_rate))
+        tail = waveform.detach().to(device="cpu", dtype=torch.float32)[..., end_sample:]
+        if tail.numel():
+            rms = float(tail.square().mean().sqrt())
+            threshold = 10.0 ** (float(tail_activity_threshold_dbfs) / 20.0)
+            active_ratio = float((tail.abs().mean(dim=1) >= threshold).float().mean())
+            tail_signal = {
+                "measured": True,
+                "start_sample": end_sample,
+                "sample_count": int(tail.shape[-1]),
+                "duration_seconds": tail.shape[-1] / sample_rate,
+                "rms_dbfs": 20.0 * math.log10(max(rms, 1e-12)),
+                "activity_threshold_dbfs": float(tail_activity_threshold_dbfs),
+                "samples_above_threshold_ratio": active_ratio,
+                "is_not_a_speech_classifier": True,
+            }
+        else:
+            tail_signal = {
+                "measured": True,
+                "start_sample": end_sample,
+                "sample_count": 0,
+                "duration_seconds": 0.0,
+                "rms_dbfs": -240.0,
+                "activity_threshold_dbfs": float(tail_activity_threshold_dbfs),
+                "samples_above_threshold_ratio": 0.0,
+                "is_not_a_speech_classifier": True,
+            }
+
+    clean_exact = unique_target_found and not before_units and not after_units
+    if len(spans) == 0:
+        status = "target_not_found"
+    elif len(spans) > 1:
+        status = "ambiguous_multiple_exact_targets"
+    elif clean_exact:
+        status = "clean_exact_target"
+    else:
+        status = "unique_target_with_lexical_extras"
+    metrics = transcript_metrics(expected_text, result["text"])
+    report = {
+        "schema": "minimax_h3_t8_dialogue_boundary_v1",
+        "status": status,
+        "unique_exact_target_found": unique_target_found,
+        "clean_exact_target": clean_exact,
+        "exact_target_span_count": len(spans),
+        "expected_text": expected_text,
+        "transcript": result["text"],
+        "transcript_metrics": metrics,
+        "target_bounds": (
+            {
+                "start_seconds": start_seconds,
+                "end_seconds": end_seconds,
+                "start_sample": round(start_seconds * sample_rate),
+                "end_sample": round(end_seconds * sample_rate),
+            }
+            if unique_target_found
+            else None
+        ),
+        "lexical_extras": {
+            "before_units": before_units,
+            "after_units": after_units,
+            "before_count": len(before_units),
+            "after_count": len(after_units),
+        },
+        "tail_signal_activity": tail_signal,
+        "asr": {
+            "engine": "faster-whisper",
+            "device": "cpu",
+            "compute_type": "int8",
+            "model_directory": str(model_path),
+            "model_reused": reused,
+            "detected_language": result["language"],
+            "language_probability": result["language_probability"],
+            "unload": {
+                "requested": bool(unload_after_analyze),
+                "released": bool(released),
+                "scope": "optional_cpu_asr_only",
+            },
+        },
+        "claims": {
+            "audio_was_modified": False,
+            "boundary_is_exact_model_ground_truth": False,
+            "tail_energy_proves_speech": False,
+        },
+        "limitations": [
+            "The boundary is accepted only when ASR finds exactly one contiguous exact target-unit sequence.",
+            "ASR can miss mumbling or hallucinated non-lexical vocalization.",
+            "Tail energy reports signal activity, not whether that signal is speech, music, ambience, or effects.",
+        ],
+    }
+    return (
+        result["text"],
+        bool(unique_target_found),
+        bool(clean_exact),
+        float(start_seconds),
+        float(end_seconds),
+        int(len(before_units)),
+        int(len(after_units)),
+        _json(report),
+    )
 
 
 def _trim_audio_to_bounds(

--- a/tests/test_dialogue_audio.py
+++ b/tests/test_dialogue_audio.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import torch
+
+import comfy.nested_tensor
+
+from h3_audio_t8_pkg.dialogue_audio import build_dialogue_safe_master
+from h3_audio_t8_pkg import speech_verification
+from h3_audio_t8_pkg.speech_verification import (
+    analyze_dialogue_boundary,
+    exact_target_word_spans,
+)
+from h3_audio_t8_pkg.timed_audio_latent import build_timed_audio_bed_lock
+from helpers import FakeAudioVAE
+
+
+def make_audio(seconds: float, sample_rate: int = 32000, value: float = 0.1):
+    samples = round(seconds * sample_rate)
+    return {
+        "waveform": torch.full((1, 2, samples), value, dtype=torch.float32),
+        "sample_rate": sample_rate,
+    }
+
+
+def word_rows(text: str, start: float = 0.0, step: float = 0.25):
+    rows = []
+    cursor = start
+    for word in text.split():
+        rows.append({"start": cursor, "end": cursor + step * 0.8, "word": word})
+        cursor += step
+    return rows
+
+
+def test_exact_target_spans_reports_repetition_instead_of_guessing():
+    words = word_rows("hello world pause hello world")
+    spans = exact_target_word_spans(words, "hello world")
+    assert len(spans) == 2
+    assert spans[0]["start_word_index"] == 0
+    assert spans[1]["start_word_index"] == 3
+
+
+def test_boundary_analyzer_reports_unique_target_and_tail_extras_without_editing(monkeypatch):
+    expected = "the door is open"
+    words = word_rows("noise the door is open muttering continues", start=0.1)
+    original = make_audio(3.0, value=0.2)
+    original_ptr = original["waveform"].data_ptr()
+
+    monkeypatch.setattr(
+        speech_verification,
+        "resolve_asr_model_directory",
+        lambda value: Path("X:/verified-model"),
+    )
+    monkeypatch.setattr(
+        speech_verification,
+        "_load_asr_model",
+        lambda path, threads: (object(), False),
+    )
+    monkeypatch.setattr(
+        speech_verification,
+        "_transcribe",
+        lambda model, audio, language, beam_size: {
+            "text": "noise the door is open muttering continues",
+            "language": "en",
+            "language_probability": 1.0,
+            "duration_seconds": 3.0,
+            "words": words,
+        },
+    )
+    monkeypatch.setattr(speech_verification, "_release_asr_model", lambda: True)
+
+    result = analyze_dialogue_boundary(
+        original,
+        expected,
+        "verified-model",
+        "English",
+    )
+    transcript, unique, clean, start, end, before, after, report_json = result
+    report = json.loads(report_json)
+
+    assert transcript.startswith("noise")
+    assert unique is True
+    assert clean is False
+    assert start == pytest.approx(words[1]["start"])
+    assert end == pytest.approx(words[4]["end"])
+    assert before == 1
+    assert after == 2
+    assert report["status"] == "unique_target_with_lexical_extras"
+    assert report["tail_signal_activity"]["is_not_a_speech_classifier"] is True
+    assert report["claims"]["audio_was_modified"] is False
+    assert original["waveform"].data_ptr() == original_ptr
+
+
+def test_boundary_analyzer_rejects_ambiguous_repeated_target(monkeypatch):
+    words = word_rows("hello world hello world")
+    monkeypatch.setattr(
+        speech_verification,
+        "resolve_asr_model_directory",
+        lambda value: Path("X:/verified-model"),
+    )
+    monkeypatch.setattr(
+        speech_verification,
+        "_load_asr_model",
+        lambda path, threads: (object(), False),
+    )
+    monkeypatch.setattr(
+        speech_verification,
+        "_transcribe",
+        lambda model, audio, language, beam_size: {
+            "text": "hello world hello world",
+            "language": "en",
+            "language_probability": 1.0,
+            "duration_seconds": 2.0,
+            "words": words,
+        },
+    )
+    monkeypatch.setattr(speech_verification, "_release_asr_model", lambda: True)
+
+    result = analyze_dialogue_boundary(
+        make_audio(2.0),
+        "hello world",
+        "verified-model",
+        "English",
+    )
+    assert result[1] is False
+    assert result[2] is False
+    assert result[3] == result[4] == 0.0
+    assert json.loads(result[-1])["status"] == "ambiguous_multiple_exact_targets"
+
+
+def test_safe_master_preserves_background_after_verified_speech_ends():
+    speech = make_audio(1.0, value=0.2)
+    music = make_audio(5.0, value=0.05)
+    ambience = make_audio(5.0, value=0.02)
+    sfx_wave = torch.zeros((1, 2, 5 * 32000), dtype=torch.float32)
+    sfx_wave[..., 4 * 32000 : 4 * 32000 + 200] = 0.3
+    sfx = {"waveform": sfx_wave, "sample_rate": 32000}
+
+    master, speech_stem, background, report_json = build_dialogue_safe_master(
+        speech,
+        True,
+        5.0,
+        music_audio=music,
+        ambience_audio=ambience,
+        sfx_audio=sfx,
+    )
+    report = json.loads(report_json)
+
+    assert master["waveform"].shape[-1] == 5 * 32000
+    assert torch.count_nonzero(speech_stem["waveform"][..., 32000:]) == 0
+    assert torch.all(background["waveform"][..., 2 * 32000 : 3 * 32000] != 0)
+    assert float(background["waveform"][..., 4 * 32000 :].abs().max()) > 0.3
+    assert torch.equal(master["waveform"], speech_stem["waveform"] + background["waveform"])
+    assert report["speech"]["action"] == "placed_without_trimming_or_time_stretch"
+    assert report["claims"]["master_tail_was_truncated_at_dialogue_end"] is False
+    assert report["exact_sample_error"] == 0
+
+
+def test_safe_master_refuses_unverified_speech_and_overflow():
+    with pytest.raises(ValueError, match="requires a true accepted signal"):
+        build_dialogue_safe_master(make_audio(1.0), False, 5.0)
+    with pytest.raises(ValueError, match="beyond target master"):
+        build_dialogue_safe_master(make_audio(5.0), True, 5.0, speech_start_seconds=0.1)
+
+
+def test_safe_master_never_silently_fits_background_stems():
+    with pytest.raises(ValueError, match="choose an explicit fit policy"):
+        build_dialogue_safe_master(
+            make_audio(1.0),
+            True,
+            5.0,
+            music_audio=make_audio(2.0),
+        )
+
+    master, _speech, background, report_json = build_dialogue_safe_master(
+        make_audio(1.0),
+        True,
+        5.0,
+        music_fit_policy="pad_or_trim",
+        music_audio=make_audio(2.0, value=0.1),
+    )
+    report = json.loads(report_json)
+    assert master["waveform"].shape[-1] == 5 * 32000
+    assert torch.count_nonzero(background["waveform"][..., 2 * 32000 :]) == 0
+    assert report["beds"]["music"]["action"].startswith("padded_")
+
+
+def test_safe_master_loop_policy_is_explicit_and_sample_exact():
+    master, speech, background, report_json = build_dialogue_safe_master(
+        make_audio(0.5, value=0.1),
+        True,
+        3.0,
+        music_fit_policy="loop_crossfade",
+        loop_crossfade_seconds=0.1,
+        music_audio=make_audio(1.0, value=0.02),
+    )
+    report = json.loads(report_json)
+    assert master["waveform"].shape == speech["waveform"].shape == background["waveform"].shape
+    assert master["waveform"].shape[-1] == 96000
+    assert report["beds"]["music"]["action"] == "looped_with_crossfade"
+    assert report["beds"]["music"]["repeat_count"] > 1
+
+
+def make_av_latent(audio_t: int = 207):
+    video = torch.randn((1, 24, 37, 4, 4))
+    audio = torch.randn((1, 32, 2, audio_t))
+    video_mask = torch.full_like(video, 0.6)
+    audio_mask = torch.full_like(audio, 0.5)
+    return {
+        "samples": comfy.nested_tensor.NestedTensor((video, audio)),
+        "noise_mask": comfy.nested_tensor.NestedTensor((video_mask, audio_mask)),
+        "kept_metadata": "yes",
+    }
+
+
+def test_timed_bed_lock_preserves_video_and_locks_tail_without_guessing():
+    source = make_av_latent()
+    source_video, _source_audio = source["samples"].unbind()
+    source_video_mask, _source_audio_mask = source["noise_mask"].unbind()
+    # FakeAudioVAE emits one latent step per 800 samples. 207 steps is exact.
+    bed = make_audio(207 * 800 / 32000, value=0.03)
+
+    output, audio_output, report_json = build_timed_audio_bed_lock(
+        source,
+        bed,
+        FakeAudioVAE(),
+        tail_lock_start_seconds=2.001,
+    )
+    out_video, out_audio = output["samples"].unbind()
+    out_video_mask, out_audio_mask = output["noise_mask"].unbind()
+    report = json.loads(report_json)
+
+    assert out_video.data_ptr() == source_video.data_ptr()
+    assert torch.equal(out_video_mask, source_video_mask)
+    assert torch.all(out_audio == 0.25)
+    # ceil(2.001 * 40) = 81: the boundary is never quantized earlier.
+    assert torch.all(out_audio_mask[..., :81] == 0.5)
+    assert torch.all(out_audio_mask[..., 81:] == 0.0)
+    assert torch.equal(audio_output["samples"], out_audio)
+    assert output["kept_metadata"] == "yes"
+    assert report["facts"]["requested_start_step_ceil"] == 81
+    assert report["facts"]["existing_audio_mask_was_cap"] is True
+    assert report["claims"]["source_separation_performed"] is False
+    assert report["claims"]["decoded_tail_quality_verified"] is False
+
+
+def test_timed_bed_lock_strict_default_rejects_duration_mismatch():
+    with pytest.raises(ValueError, match="different H3 latent duration"):
+        build_timed_audio_bed_lock(
+            make_av_latent(),
+            make_audio(1.0),
+            FakeAudioVAE(),
+            tail_lock_start_seconds=0.5,
+        )
+
+
+def test_timed_bed_lock_explicit_fit_and_transition_are_reported():
+    source = make_av_latent()
+    source.pop("noise_mask")
+    output, _audio_output, report_json = build_timed_audio_bed_lock(
+        source,
+        make_audio(1.0),
+        FakeAudioVAE(),
+        tail_lock_start_seconds=0.5,
+        transition_seconds=0.05,
+        audio_latent_fit_policy="fit_reported",
+    )
+    _video_mask, audio_mask = output["noise_mask"].unbind()
+    report = json.loads(report_json)
+
+    assert report["facts"]["audio_latent_fit_action"].startswith("zero_padded_")
+    assert report["facts"]["transition_steps"] == 2
+    assert report["facts"]["fully_locked_start_step"] == 22
+    assert torch.all(audio_mask[..., :20] == 1.0)
+    assert torch.all(audio_mask[..., 20] == 1.0)
+    assert torch.all(audio_mask[..., 21] == 0.5)
+    assert torch.all(audio_mask[..., 22:] == 0.0)
+
+
+def test_timed_bed_lock_never_increases_tail_freedom():
+    with pytest.raises(ValueError, match="cannot exceed"):
+        build_timed_audio_bed_lock(
+            make_av_latent(),
+            make_audio(207 * 800 / 32000),
+            FakeAudioVAE(),
+            tail_lock_start_seconds=1.0,
+            head_denoise_strength=0.2,
+            tail_denoise_strength=0.3,
+        )

--- a/tests/test_preflight_and_registration.py
+++ b/tests/test_preflight_and_registration.py
@@ -16,7 +16,7 @@ def test_all_nodes_register_with_unique_ids_and_valid_schemas():
     node_classes = asyncio.run(extension.get_node_list())
     schemas = [node.define_schema() for node in node_classes]
     ids = [schema.node_id for schema in schemas]
-    assert len(ids) == 51
+    assert len(ids) == 54
     assert len(ids) == len(set(ids))
     features = json.loads(
         (Path(__file__).resolve().parents[1] / "features.json").read_text(
@@ -131,10 +131,15 @@ def test_all_nodes_register_with_unique_ids_and_valid_schemas():
         "MiniMaxH3SpeechLongFormComposeT8",
         "MiniMaxH3JointDialogueConditioningT8",
     ]
-    assert ids[48:] == [
+    assert ids[48:51] == [
         "MiniMaxH3SourceMediaWindowT8",
         "MiniMaxH3SourceAVPrepareT8",
         "MiniMaxH3AVLatentSeparateT8",
+    ]
+    assert ids[51:] == [
+        "MiniMaxH3DialogueBoundaryAnalyzerT8",
+        "MiniMaxH3DialogueSafeMasterT8",
+        "MiniMaxH3TimedAudioBedLockT8",
     ]
     assert ids[23:25] == [
         "MiniMaxH3LongVideoBackgroundStartT8",
@@ -149,10 +154,21 @@ def test_all_nodes_register_with_unique_ids_and_valid_schemas():
     assert visual_strength.is_experimental is True
     assert visual_strength.category == "T8/MiniMax H3/Conditioning/Experimental"
 
-    for source_av_id in ids[48:]:
+    for source_av_id in ids[48:51]:
         source_av_schema = schemas[ids.index(source_av_id)]
         assert source_av_schema.is_experimental is True
         assert source_av_schema.category == "T8/MiniMax H3/Source AV/Experimental"
+
+    for dialogue_audio_id in ids[51:]:
+        dialogue_audio_schema = schemas[ids.index(dialogue_audio_id)]
+        assert dialogue_audio_schema.is_experimental is True
+        assert dialogue_audio_schema.category == "T8/MiniMax H3/Speech/Experimental"
+
+    timed_bed = schemas[ids.index("MiniMaxH3TimedAudioBedLockT8")]
+    timed_inputs = {item.id: item for item in timed_bed.inputs}
+    assert timed_inputs["tail_denoise_strength"].default == 0.0
+    assert timed_inputs["transition_seconds"].default == 0.0
+    assert timed_inputs["audio_latent_fit_policy"].default == "strict"
 
     source_media = schemas[ids.index("MiniMaxH3SourceMediaWindowT8")]
     media_inputs = {item.id: item for item in source_media.inputs}
@@ -984,3 +1000,92 @@ def test_frontend_still_edit_workflow_uses_native_22_frame_ref2va_target():
             or link_type == "*"
         )
         assert target["inputs"][target_slot]["type"] == link_type
+
+
+def test_dialogue_safe_master_examples_require_verified_independent_stems():
+    root = Path(__file__).resolve().parents[1]
+    api = json.loads((root / "examples" / "dialogue_safe_master_api.json").read_text(
+        encoding="utf-8"
+    ))
+    analyzer = next(
+        node for node in api.values()
+        if node["class_type"] == "MiniMaxH3DialogueBoundaryAnalyzerT8"
+    )
+    master = next(
+        node for node in api.values()
+        if node["class_type"] == "MiniMaxH3DialogueSafeMasterT8"
+    )
+    analyzer_id = next(key for key, value in api.items() if value is analyzer)
+    assert master["inputs"]["speech_accepted"] == [analyzer_id, 2]
+    assert master["inputs"]["music_fit_policy"] == "strict"
+    assert master["inputs"]["ambience_fit_policy"] == "strict"
+    assert master["inputs"]["sfx_fit_policy"] == "strict"
+    assert master["inputs"]["target_duration_seconds"] == 10.0
+    load_titles = {
+        node.get("_meta", {}).get("title", "")
+        for node in api.values()
+        if node["class_type"] == "LoadAudio"
+    }
+    assert any("independent speech stem" in title for title in load_titles)
+    assert any("music stem" in title for title in load_titles)
+    assert any("ambience stem" in title for title in load_titles)
+    assert any("SFX stem" in title for title in load_titles)
+
+    frontend = json.loads(
+        (root / "examples" / "workflows" / "H3_Dialogue_Safe_Master_EXP.json")
+        .read_text(encoding="utf-8")
+    )
+    nodes = {node["id"]: node for node in frontend["nodes"]}
+    assert frontend["last_node_id"] == max(nodes)
+    assert frontend["last_link_id"] == max(link[0] for link in frontend["links"])
+    assert {
+        "MiniMaxH3DialogueBoundaryAnalyzerT8",
+        "MiniMaxH3DialogueSafeMasterT8",
+    } <= {node["type"] for node in nodes.values()}
+    for link_id, source, output_slot, target, input_slot, link_type in frontend["links"]:
+        assert nodes[target]["inputs"][input_slot]["link"] == link_id
+        assert link_id in (nodes[source]["outputs"][output_slot].get("links") or [])
+        assert nodes[source]["outputs"][output_slot]["type"] == link_type
+        assert nodes[target]["inputs"][input_slot]["type"] == link_type
+
+
+def test_timed_background_bed_example_is_opt_in_and_routes_locked_latent_twice():
+    root = Path(__file__).resolve().parents[1]
+    api = json.loads((root / "examples" / "dialogue_timed_bed_lock_api.json").read_text(
+        encoding="utf-8"
+    ))
+    ids_by_type = {
+        value["class_type"]: key
+        for key, value in api.items()
+    }
+    timed_id = ids_by_type["MiniMaxH3TimedAudioBedLockT8"]
+    timed = api[timed_id]
+    sampler_setup = api[ids_by_type["MiniMaxH3DualClockSamplerT8"]]
+    sampler = api[ids_by_type["SamplerCustomAdvanced"]]
+    boundary_id = ids_by_type["PrimitiveFloat"]
+
+    assert timed["inputs"]["tail_lock_start_seconds"] == [boundary_id, 0]
+    assert timed["inputs"]["tail_denoise_strength"] == 0.0
+    assert timed["inputs"]["transition_seconds"] == 0.0
+    assert timed["inputs"]["audio_latent_fit_policy"] == "fit_reported"
+    assert sampler_setup["inputs"]["av_latent"] == [timed_id, 0]
+    assert sampler["inputs"]["latent_image"] == [timed_id, 0]
+    assert sampler_setup["inputs"]["steps"] == 4
+
+    frontend = json.loads(
+        (root / "examples" / "workflows" / "H3_Dialogue_Timed_Background_Bed_Lock_EXP.json")
+        .read_text(encoding="utf-8")
+    )
+    nodes = {node["id"]: node for node in frontend["nodes"]}
+    timed_frontend = next(
+        node for node in nodes.values()
+        if node["type"] == "MiniMaxH3TimedAudioBedLockT8"
+    )
+    assert timed_frontend["widgets_values"] == [1.0, 0.0, 0.0, "fit_reported"]
+    assert frontend["last_node_id"] == max(nodes)
+    assert frontend["last_link_id"] == max(link[0] for link in frontend["links"])
+    for link_id, source, output_slot, target, input_slot, link_type in frontend["links"]:
+        assert nodes[target]["inputs"][input_slot]["link"] == link_id
+        assert link_id in (nodes[source]["outputs"][output_slot].get("links") or [])
+        assert nodes[source]["outputs"][output_slot]["type"] == link_type
+        assert nodes[target]["inputs"][input_slot]["type"] == link_type

--- a/timed_audio_latent.py
+++ b/timed_audio_latent.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+
+import torch
+
+import comfy.nested_tensor
+import comfy.utils
+
+from .core import (
+    AUDIO_LATENT_FPS,
+    classify_h3_vae,
+    encode_audio_once,
+    nested_av_parts,
+    split_noise_masks,
+)
+
+
+TIMED_AUDIO_BED_SCHEMA = "minimax_h3_t8_timed_audio_bed_lock_v1"
+AUDIO_LATENT_FIT_POLICIES = ("strict", "fit_reported")
+
+
+def _fit_encoded_bed(
+    encoded: torch.Tensor,
+    template: torch.Tensor,
+    policy: str,
+) -> tuple[torch.Tensor, str]:
+    if policy not in AUDIO_LATENT_FIT_POLICIES:
+        raise ValueError(f"unknown audio latent fit policy: {policy}")
+    if encoded.ndim != 4:
+        raise ValueError(
+            "The audio VAE must return [B,C,stereo,T] latent data; "
+            f"got {tuple(encoded.shape)}"
+        )
+    if encoded.shape[:-1] != template.shape[:-1]:
+        raise ValueError(
+            "Background-bed latent layout does not match the H3 AV audio stream: "
+            f"encoded={tuple(encoded.shape)}, target={tuple(template.shape)}"
+        )
+    current_t = int(encoded.shape[-1])
+    target_t = int(template.shape[-1])
+    if current_t == target_t:
+        return encoded.to(device=template.device, dtype=template.dtype), "exact"
+    if policy == "strict":
+        raise ValueError(
+            "Background audio encoded to a different H3 latent duration: "
+            f"encoded T={current_t}, AV target T={target_t}. Supply an exact-duration bed "
+            "or explicitly choose fit_reported."
+        )
+    if current_t > target_t:
+        fitted = encoded[..., :target_t]
+        action = f"trimmed_{current_t - target_t}_latent_steps"
+    else:
+        padding = encoded.new_zeros((*encoded.shape[:-1], target_t - current_t))
+        fitted = torch.cat((encoded, padding), dim=-1)
+        action = f"zero_padded_{target_t - current_t}_latent_steps"
+    return fitted.to(device=template.device, dtype=template.dtype), action
+
+
+def _mask_like(mask, samples: torch.Tensor) -> torch.Tensor:
+    if mask is None:
+        return torch.ones_like(samples)
+    if not isinstance(mask, torch.Tensor):
+        raise ValueError("H3 noise masks must be torch.Tensor values")
+    mask = mask.to(device=samples.device, dtype=samples.dtype)
+    if tuple(mask.shape) != tuple(samples.shape):
+        mask = comfy.utils.reshape_mask(mask, samples.shape)
+    return mask.clamp(0.0, 1.0)
+
+
+def build_timed_audio_bed_lock(
+    av_latent: Mapping,
+    background_audio: Mapping,
+    audio_vae,
+    tail_lock_start_seconds: float,
+    head_denoise_strength: float = 1.0,
+    tail_denoise_strength: float = 0.0,
+    transition_seconds: float = 0.0,
+    audio_latent_fit_policy: str = "strict",
+):
+    if not isinstance(av_latent, Mapping):
+        raise ValueError("av_latent must be a connected H3 joint AV LATENT value")
+    if audio_vae is None:
+        raise ValueError("audio_vae must be connected")
+    if classify_h3_vae(audio_vae) != "audio":
+        raise ValueError("audio_vae must be the MiniMax H3 audio VAE, not the video VAE")
+    numeric = {
+        "tail_lock_start_seconds": tail_lock_start_seconds,
+        "head_denoise_strength": head_denoise_strength,
+        "tail_denoise_strength": tail_denoise_strength,
+        "transition_seconds": transition_seconds,
+    }
+    for name, value in numeric.items():
+        if not math.isfinite(float(value)):
+            raise ValueError(f"{name} must be finite")
+    if tail_lock_start_seconds < 0.0:
+        raise ValueError("tail_lock_start_seconds must be nonnegative")
+    if transition_seconds < 0.0 or transition_seconds > 10.0:
+        raise ValueError("transition_seconds must be between 0 and 10")
+    if not 0.0 <= head_denoise_strength <= 1.0:
+        raise ValueError("head_denoise_strength must be between 0 and 1")
+    if not 0.0 <= tail_denoise_strength <= 1.0:
+        raise ValueError("tail_denoise_strength must be between 0 and 1")
+    if tail_denoise_strength > head_denoise_strength:
+        raise ValueError(
+            "tail_denoise_strength cannot exceed head_denoise_strength; this node must not "
+            "silently increase generation freedom after the dialogue boundary"
+        )
+
+    video, template_audio = nested_av_parts(dict(av_latent))
+    encoded = encode_audio_once(audio_vae, background_audio)
+    fitted, fit_action = _fit_encoded_bed(
+        encoded,
+        template_audio,
+        audio_latent_fit_policy,
+    )
+    target_t = int(fitted.shape[-1])
+    requested_start_step = math.ceil(float(tail_lock_start_seconds) * AUDIO_LATENT_FPS)
+    if requested_start_step >= target_t:
+        raise ValueError(
+            "tail_lock_start_seconds is outside the H3 audio latent timeline: "
+            f"requested step {requested_start_step}, available T={target_t}"
+        )
+    start_step = max(0, requested_start_step)
+    transition_steps = round(float(transition_seconds) * AUDIO_LATENT_FPS)
+    transition_end = min(target_t, start_step + transition_steps)
+
+    desired_1d = fitted.new_full((target_t,), float(tail_denoise_strength))
+    if start_step:
+        desired_1d[:start_step] = float(head_denoise_strength)
+    if transition_end > start_step:
+        # A transition begins at the explicit boundary and reaches the tail
+        # strength later. Default zero avoids an implicit softened interval.
+        desired_1d[start_step:transition_end] = torch.linspace(
+            float(head_denoise_strength),
+            float(tail_denoise_strength),
+            transition_end - start_step + 1,
+            device=fitted.device,
+            dtype=fitted.dtype,
+        )[:-1]
+    desired_mask = desired_1d.reshape(1, 1, 1, -1).expand_as(fitted)
+
+    video_mask, input_audio_mask = split_noise_masks(
+        dict(av_latent),
+        video,
+        template_audio,
+    )
+    video_mask = _mask_like(video_mask, video)
+    existing_audio_cap = _mask_like(input_audio_mask, fitted)
+    effective_audio_mask = torch.minimum(existing_audio_cap, desired_mask)
+
+    output = dict(av_latent)
+    output["samples"] = comfy.nested_tensor.NestedTensor((video, fitted))
+    output["noise_mask"] = comfy.nested_tensor.NestedTensor(
+        (video_mask, effective_audio_mask)
+    )
+    audio_output = {
+        key: value
+        for key, value in output.items()
+        if key not in {"samples", "noise_mask"}
+    }
+    audio_output["samples"] = fitted
+    audio_output["noise_mask"] = effective_audio_mask
+
+    fully_locked_start_step = transition_end if transition_steps else start_step
+    report = {
+        "schema": TIMED_AUDIO_BED_SCHEMA,
+        "status": "experimental_timed_background_bed_ready",
+        "facts": {
+            "audio_latent_fps": AUDIO_LATENT_FPS,
+            "audio_latent_t": target_t,
+            "timeline_seconds": target_t / AUDIO_LATENT_FPS,
+            "requested_tail_lock_start_seconds": float(tail_lock_start_seconds),
+            "requested_start_step_ceil": requested_start_step,
+            "actual_boundary_seconds_on_40hz_grid": start_step / AUDIO_LATENT_FPS,
+            "transition_seconds_requested": float(transition_seconds),
+            "transition_steps": transition_steps,
+            "fully_locked_start_step": fully_locked_start_step,
+            "fully_locked_start_seconds_on_40hz_grid": (
+                fully_locked_start_step / AUDIO_LATENT_FPS
+            ),
+            "head_denoise_strength": float(head_denoise_strength),
+            "tail_denoise_strength": float(tail_denoise_strength),
+            "audio_latent_fit_policy": audio_latent_fit_policy,
+            "audio_latent_fit_action": fit_action,
+            "existing_audio_mask_was_cap": input_audio_mask is not None,
+            "video_mask_preserved_as_constraint": True,
+        },
+        "warnings": [
+            "This requires an independent full-duration background bed; it does not separate "
+            "dialogue from a mixed H3 master.",
+            "The boundary is quantized to the 40Hz H3 audio-latent grid and is not a "
+            "sample-exact decoded speech endpoint.",
+            "A nonzero transition delays the fully locked tail and may permit changes inside "
+            "that transition interval.",
+        ],
+        "claims": {
+            "source_separation_performed": False,
+            "decoded_tail_quality_verified": False,
+            "mouth_stop_guaranteed": False,
+            "denoise_strength_is_calibrated_linear_weight": False,
+            "locked_tail_latent_endpoint_requested": tail_denoise_strength == 0.0,
+            "video_samples_modified": False,
+            "memory_safe": False,
+        },
+    }
+    return output, audio_output, json.dumps(report, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## What changed
- Append three EXP nodes for dialogue boundary analysis, dialogue-safe master assembly, and timed background-bed latent locking.
- Preserve all existing 51 node IDs, ordering, defaults, and legacy workflows.
- Add API/UI example workflows, README guidance, feature metadata, and verification notes.
- Document scientific limits: this mitigates unwanted extra speech without truncating the full soundtrack, but does not claim source separation, sample-exact speech stopping, or seamless latent locking.

## Verification
- Full suite before release: 235 passed, 4 warnings.
- Final targeted suite in the ComfyUI embedded runtime: 37 passed, 4 warnings.
- Ruff checks passed.
- Python compile, JSON parsing, diff checks, isolated ComfyUI import/object-info, real H3 four-step latent-lock probe, and real Audio VAE boundary probe passed.

## Scope
- `SKILL.md`, `roadmap.md`, and local artifacts are intentionally excluded.